### PR TITLE
feat: add snippet search to rust service

### DIFF
--- a/rust_search/src/main.rs
+++ b/rust_search/src/main.rs
@@ -1,6 +1,7 @@
 mod common;
 mod sections;
 mod skills;
+mod snippets;
 
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -460,6 +461,7 @@ async fn main() -> std::io::Result<()> {
             .service(query_handler)
             .service(sections::md_handler)
             .service(skills::skills_handler)
+            .service(snippets::search_handler)
     });
     server.bind(addr)?.run().await
 }

--- a/rust_search/src/snippets/handler.rs
+++ b/rust_search/src/snippets/handler.rs
@@ -1,0 +1,159 @@
+use actix_web::web::{Data, Query};
+use actix_web::{get, HttpRequest, HttpResponse};
+use qdrant_client::qdrant::r#match::MatchValue;
+use qdrant_client::qdrant::value::Kind;
+use qdrant_client::qdrant::{
+    Condition, Document, FacetCountsBuilder, Filter, PrefetchQueryBuilder, QueryPointsBuilder, Rrf,
+    ScoredPoint, VectorInput,
+};
+use qdrant_client::Qdrant;
+use serde::Deserialize;
+
+use super::models::{Snippet, SnippetSearchResult};
+
+const SNIPPET_COLLECTION_NAME: &str = "snippet-search";
+const SNIPPET_ENCODER: &str = "mixedbread-ai/mxbai-embed-large-v1";
+
+fn default_limit() -> u64 {
+    3
+}
+
+#[derive(Deserialize)]
+struct SnippetSearch {
+    query: String,
+    language: String,
+    #[serde(default = "default_limit")]
+    limit: u64,
+    format: Option<String>,
+}
+
+async fn find_latest_revision(client: &Qdrant) -> anyhow::Result<i64> {
+    let result = client
+        .facet(FacetCountsBuilder::new(SNIPPET_COLLECTION_NAME, "revision").limit(1_000_000))
+        .await?;
+    let max = result
+        .hits
+        .into_iter()
+        .filter_map(|hit| {
+            hit.value.and_then(|v| match v.variant? {
+                qdrant_client::qdrant::facet_value::Variant::IntegerValue(n) => Some(n),
+                _ => None,
+            })
+        })
+        .max()
+        .unwrap_or(0);
+    Ok(max)
+}
+
+fn parse_snippets(points: Vec<ScoredPoint>) -> Vec<Snippet> {
+    points
+        .into_iter()
+        .filter_map(|p| Snippet::from_payload(p.payload))
+        .collect()
+}
+
+async fn search_snippets(
+    client: &Qdrant,
+    query: &str,
+    language: &str,
+    limit: u64,
+) -> anyhow::Result<SnippetSearchResult> {
+    let revision = find_latest_revision(client).await?;
+
+    let mut bm25_doc = Document::new(query, "qdrant/bm25");
+    bm25_doc.options.insert(
+        "language".to_string(),
+        qdrant_client::qdrant::Value {
+            kind: Some(Kind::StringValue("none".to_string())),
+        },
+    );
+
+    let result = client
+        .query(
+            QueryPointsBuilder::new(SNIPPET_COLLECTION_NAME)
+                .add_prefetch(
+                    PrefetchQueryBuilder::default()
+                        .query(VectorInput::from(Document::new(query, SNIPPET_ENCODER)))
+                        .using("dense")
+                        .limit(20u64)
+                        .build(),
+                )
+                .add_prefetch(
+                    PrefetchQueryBuilder::default()
+                        .query(VectorInput::from(bm25_doc))
+                        .using("sparse")
+                        .limit(20u64)
+                        .build(),
+                )
+                .query(qdrant_client::qdrant::Query::new_rrf(Rrf {
+                    k: Some(1),
+                    ..Default::default()
+                }))
+                .filter(Filter::must(vec![
+                    Condition::matches("language", MatchValue::Keyword(language.to_string())),
+                    Condition::matches("revision", MatchValue::Integer(revision)),
+                ]))
+                .limit(limit)
+                .with_payload(true),
+        )
+        .await?;
+
+    Ok(SnippetSearchResult(parse_snippets(result.result)))
+}
+
+fn resolve_format(format_param: Option<&str>, accept: Option<&str>) -> &'static str {
+    if let Some(f) = format_param {
+        match f.trim().to_lowercase().as_str() {
+            "json" => return "json",
+            "markdown" => return "markdown",
+            _ => {}
+        }
+    }
+    if let Some(accept) = accept {
+        for part in accept.split(',') {
+            let mime = part.split(';').next().unwrap_or("").trim().to_lowercase();
+            if mime == "application/json" {
+                return "json";
+            }
+            if mime == "text/markdown" {
+                return "markdown";
+            }
+        }
+    }
+    "markdown"
+}
+
+#[get("/snippets/search")]
+pub async fn search_handler(
+    req: HttpRequest,
+    query: Query<SnippetSearch>,
+    qdrant: Data<Qdrant>,
+) -> HttpResponse {
+    let SnippetSearch {
+        query: q,
+        language,
+        limit,
+        format,
+    } = query.into_inner();
+    let accept = req.headers().get("accept").and_then(|v| v.to_str().ok());
+    let fmt = resolve_format(format.as_deref(), accept);
+
+    match search_snippets(qdrant.get_ref(), &q, &language, limit).await {
+        Ok(result) => {
+            log::info!("snippets={}", result.0.len());
+            if fmt == "json" {
+                HttpResponse::Ok()
+                    .content_type("application/json")
+                    .body(result.to_json())
+            } else {
+                HttpResponse::Ok()
+                    .content_type("text/markdown; charset=utf-8")
+                    .body(result.to_markdown())
+            }
+        }
+        Err(e) => {
+            log::error!("Snippet search error: {}", e);
+            HttpResponse::InternalServerError().body(e.to_string())
+        }
+    }
+}

--- a/rust_search/src/snippets/handler.rs
+++ b/rust_search/src/snippets/handler.rs
@@ -3,8 +3,8 @@ use actix_web::{get, HttpRequest, HttpResponse};
 use qdrant_client::qdrant::r#match::MatchValue;
 use qdrant_client::qdrant::value::Kind;
 use qdrant_client::qdrant::{
-    Condition, Document, FacetCountsBuilder, Filter, PrefetchQueryBuilder, QueryPointsBuilder, Rrf,
-    ScoredPoint, VectorInput,
+    Condition, Document, Filter, PrefetchQueryBuilder, QueryPointsBuilder, Rrf, ScoredPoint,
+    VectorInput,
 };
 use qdrant_client::Qdrant;
 use serde::Deserialize;
@@ -27,24 +27,6 @@ struct SnippetSearch {
     format: Option<String>,
 }
 
-async fn find_latest_revision(client: &Qdrant) -> anyhow::Result<i64> {
-    let result = client
-        .facet(FacetCountsBuilder::new(SNIPPET_COLLECTION_NAME, "revision").limit(1_000_000))
-        .await?;
-    let max = result
-        .hits
-        .into_iter()
-        .filter_map(|hit| {
-            hit.value.and_then(|v| match v.variant? {
-                qdrant_client::qdrant::facet_value::Variant::IntegerValue(n) => Some(n),
-                _ => None,
-            })
-        })
-        .max()
-        .unwrap_or(0);
-    Ok(max)
-}
-
 fn parse_snippets(points: Vec<ScoredPoint>) -> Vec<Snippet> {
     points
         .into_iter()
@@ -58,8 +40,6 @@ async fn search_snippets(
     language: &str,
     limit: u64,
 ) -> anyhow::Result<SnippetSearchResult> {
-    let revision = find_latest_revision(client).await?;
-
     let mut bm25_doc = Document::new(query, "qdrant/bm25");
     bm25_doc.options.insert(
         "language".to_string(),
@@ -89,10 +69,10 @@ async fn search_snippets(
                     k: Some(1),
                     ..Default::default()
                 }))
-                .filter(Filter::must(vec![
-                    Condition::matches("language", MatchValue::Keyword(language.to_string())),
-                    Condition::matches("revision", MatchValue::Integer(revision)),
-                ]))
+                .filter(Filter::must(vec![Condition::matches(
+                    "language",
+                    MatchValue::Keyword(language.to_string()),
+                )]))
                 .limit(limit)
                 .with_payload(true),
         )

--- a/rust_search/src/snippets/mod.rs
+++ b/rust_search/src/snippets/mod.rs
@@ -1,0 +1,4 @@
+mod handler;
+mod models;
+
+pub use handler::search_handler;

--- a/rust_search/src/snippets/models.rs
+++ b/rust_search/src/snippets/models.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use qdrant_client::qdrant::Value;
+use qdrant_client::Payload;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SourceInfo {
+    pub url: String,
+    pub hash: String,
+    pub lines: Option<(i64, i64)>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnippetContext {
+    pub before: String,
+    pub after: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Snippet {
+    pub code: String,
+    pub language: String,
+    pub version: String,
+    pub revision: i64,
+    pub package_name: String,
+    pub source: SourceInfo,
+    pub context: SnippetContext,
+    pub description: Option<String>,
+}
+
+impl Snippet {
+    pub fn from_payload(payload: HashMap<String, Value>) -> Option<Self> {
+        Payload::from(payload).deserialize().ok()
+    }
+}
+
+pub struct SnippetSearchResult(pub Vec<Snippet>);
+
+impl SnippetSearchResult {
+    pub fn to_json(&self) -> String {
+        let values: Vec<serde_json::Value> = self
+            .0
+            .iter()
+            .map(|s| serde_json::to_value(s).unwrap_or_default())
+            .collect();
+        serde_json::json!({ "result": values }).to_string()
+    }
+
+    pub fn to_markdown(&self) -> String {
+        if self.0.is_empty() {
+            return "No snippets found.".to_string();
+        }
+        let mut blocks: Vec<String> = Vec::new();
+        for (i, s) in self.0.iter().enumerate() {
+            blocks.push(format!("## Snippet {}\n", i + 1));
+            blocks.push(format!(
+                "*{}* (v{}) — {}\n",
+                s.package_name, s.version, s.source.url
+            ));
+            if let Some(ref desc) = s.description {
+                blocks.push(format!("{}\n", desc));
+            }
+            blocks.push(format!("```{}\n{}\n```\n", s.language, s.code));
+        }
+        blocks.join("\n")
+    }
+}

--- a/site_search/snippets.py
+++ b/site_search/snippets.py
@@ -22,6 +22,8 @@ from qdrant_client.http.exceptions import ResponseHandlingException
 from qdrant_client.http.models import (
     Distance,
     Document,
+    Filter,
+    HasIdCondition,
     PointStruct,
     TextIndexParams,
     TextIndexType,
@@ -129,7 +131,7 @@ class Snippet(BaseModel):
     code: str
     language: str
     version: str
-    revision: int
+    revision: int | None = None
     package_name: str
     source: SourceInfo
     context: SnippetContext
@@ -254,7 +256,7 @@ def _format_context(
 
 
 def _extract_from_markdown_tree(
-    content: str, root: SyntaxTreeNode, source: str, source_hash: str, revision: int
+    content: str, root: SyntaxTreeNode, source: str, source_hash: str
 ) -> list[Snippet]:
     snippets: list[Snippet] = []
 
@@ -273,7 +275,6 @@ def _extract_from_markdown_tree(
                     ),
                     context=_format_context(node, content),
                     version="latest",
-                    revision=revision,
                 )
             )
     return snippets
@@ -295,7 +296,7 @@ async def _generate_descriptions(
         return len(tasks)
 
 
-def _parse_markdown(url: str, revision: int) -> _ParsingResult:
+def _parse_markdown(url: str) -> _ParsingResult:
     resp = requests.get(urljoin(url, "index.md"))
     if not resp.ok:
         return _ParsingResult(snippets=[], url=url)
@@ -305,18 +306,8 @@ def _parse_markdown(url: str, revision: int) -> _ParsingResult:
 
     tokens = MarkdownIt("commonmark").parse(document)
     root = SyntaxTreeNode(tokens)
-    snippets = _extract_from_markdown_tree(document, root, url, md_hash, revision)
+    snippets = _extract_from_markdown_tree(document, root, url, md_hash)
     return _ParsingResult(snippets=snippets, url=url)
-
-
-def find_latest_revision(qdrant_client: QdrantClient) -> int:
-    revisions = [
-        int(hit.value)
-        for hit in qdrant_client.facet(
-            SNIPPET_COLLECTION_NAME, key="revision", limit=1000000
-        ).hits
-    ]
-    return max(revisions, default=0)
 
 
 def main():
@@ -431,53 +422,82 @@ def main():
             wait=True,
         )
 
-    revision = find_latest_revision(qdrant_client)
-
+    run_ts = int(time.time())
     urls = _all_sitemap_urls("https://qdrant.tech/", "https://qdrant.tech/sitemap.xml")
 
     snippets: list[Snippet] = []
-    existing_vectors: dict[str | int | UUID, VectorStruct | None] = {}
+    current_uuids: set[str] = set()
+    existing_uuids: set[str] = set()
     existing_descriptions: dict[str | int | UUID, str | None] = {}
+    failed_urls: list[str] = []
+
     with concurrent.futures.ProcessPoolExecutor(max_workers=10) as pool:
-        futures = [pool.submit(_parse_markdown, url, revision + 1) for url in urls]
+        futures = {pool.submit(_parse_markdown, url): url for url in urls}
 
         for future in tqdm.tqdm(
             concurrent.futures.as_completed(futures), total=len(urls)
         ):
-            result = future.result()
+            url = futures[future]
+            try:
+                result = future.result()
+            except Exception as e:
+                logger.error(f"Failed to parse {url}: {e}")
+                failed_urls.append(url)
+                continue
 
             if len(result.snippets) == 0:
                 continue
+
+            current_uuids.update(snippet.uuid for snippet in result.snippets)
 
             existing_points = qdrant_client.retrieve(
                 SNIPPET_COLLECTION_NAME,
                 ids=[snippet.uuid for snippet in result.snippets],
                 with_payload=True,
-                with_vectors=True,
+                with_vectors=False,
             )
 
             for point in existing_points:
-                existing_vectors[point.id] = point.vector  # ty:ignore[invalid-assignment]
+                existing_uuids.add(str(point.id))
                 existing_descriptions[point.id] = (point.payload or {}).get(
                     "description"
                 )
 
             snippets.extend(result.snippets)
 
-    num_generated = asyncio.run(_generate_descriptions(snippets, existing_descriptions))
+    new_snippets = [s for s in snippets if s.uuid not in existing_uuids]
+    for snippet in new_snippets:
+        snippet.revision = run_ts
 
-    batches: list[list[Snippet]] = list(batched(snippets, 8))
+    num_generated = asyncio.run(_generate_descriptions(new_snippets, existing_descriptions))
+
+    batches: list[list[Snippet]] = list(batched(new_snippets, 8))
     for batch in tqdm.tqdm(batches, total=len(batches)):
         retry(qdrant_client.upsert, max_retries=10)(
             SNIPPET_COLLECTION_NAME,
-            points=[
-                snippet.as_point(
-                    SNIPPET_ENCODER, vector=existing_vectors.get(snippet.uuid)
-                )
-                for snippet in batch
-            ],
+            points=[snippet.as_point(SNIPPET_ENCODER) for snippet in batch],
         )
-    logger.info(f"Generated descriptions for {num_generated} snippets")
+    logger.info(
+        f"Upserted {len(new_snippets)} new snippets, "
+        f"generated {num_generated} descriptions"
+    )
+
+    if failed_urls:
+        logger.warning(
+            f"Skipping stale-point deletion: {len(failed_urls)} URL(s) failed "
+            f"({failed_urls[:5]}{'...' if len(failed_urls) > 5 else ''}). "
+            f"Re-run indexing to clean up stale snippets."
+        )
+        return
+
+    qdrant_client.delete(
+        SNIPPET_COLLECTION_NAME,
+        points_selector=Filter(
+            must_not=[HasIdCondition(has_id=list(current_uuids))]
+        ),
+        wait=True,
+    )
+    logger.info(f"Deleted stale snippets not in current crawl of {len(current_uuids)} UUIDs")
 
 
 if __name__ == "__main__":

--- a/site_search/snippets_service.py
+++ b/site_search/snippets_service.py
@@ -31,17 +31,7 @@ class Searcher:
             local_inference_batch_size=32,
         )
 
-    def find_latest_revision(self) -> int:
-        revisions = [
-            int(hit.value)
-            for hit in self.client.facet(
-                SNIPPET_COLLECTION_NAME, key="revision", limit=1000000
-            ).hits
-        ]
-        return max(revisions, default=0)
-
     def search(self, query: str, language: str, limit: int = 3) -> list[Snippet]:
-        revision = self.find_latest_revision()
         points = self.client.query_points(
             collection_name=SNIPPET_COLLECTION_NAME,
             prefetch=[
@@ -64,10 +54,6 @@ class Searcher:
                     qdrant_models.FieldCondition(
                         key="language",
                         match=qdrant_models.MatchValue(value=language),
-                    ),
-                    qdrant_models.FieldCondition(
-                        key="revision",
-                        match=qdrant_models.MatchValue(value=revision),
                     ),
                 ]
             ),


### PR DESCRIPTION
Mostly written by claude code, reviewed and tested manually. Open questions:

- Do we want to keep the option to return json or do we want to rip it out because noone uses it?
- Currently listening on `/snippets/search`, might not be ideal for plumbing to another domain
- Uses cloud inference, because `mixedbread-ai/mxbai-embed-large-v1` is larger