### PR TITLE
Log real client IP via `X-Forwarded-For` in access logs

### DIFF
--- a/rust_search/src/main.rs
+++ b/rust_search/src/main.rs
@@ -441,6 +441,9 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(qdrant.clone())
             .wrap(cors)
+            // Actix's default Logger format plus one appended field (client IP from the
+            // reverse-proxy hop). Field order is load-bearing for a downstream parser: append
+            // new fields, never reorder or insert, or that parser breaks.
             .wrap(middleware::Logger::new(
                 "%a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T \"%{X-Forwarded-For}i\"",
             ))

--- a/rust_search/src/main.rs
+++ b/rust_search/src/main.rs
@@ -441,7 +441,9 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(qdrant.clone())
             .wrap(cors)
-            .wrap(middleware::Logger::default())
+            .wrap(middleware::Logger::new(
+                "%a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T \"%{X-Forwarded-For}i\"",
+            ))
             .service(query_handler)
             .service(sections::md_handler)
             .service(skills::skills_handler)


### PR DESCRIPTION
## Overview

The Actix Logger currently records only the peer address (%a), which is the sibling reverse-proxy container's IP on the vast majority (almost 90%) of requests, making unique visitors, sessions, and geography impossible to compute. This appends `%{X-Forwarded-For}i` as a new quoted field at the end of the existing format string, preserving field order and count ("-" when absent) so the external log parser keeps working unchanged.