### PR TITLE
sections: hybrid dense+bm25 (RRF) for /md section search — fixes vocabulary-collision misses

### DIFF
--- a/site_search/config.py
+++ b/site_search/config.py
@@ -16,6 +16,7 @@ QDRANT_PORT = os.environ.get("QDRANT_PORT", 6333)
 QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY")
 
 NEURAL_ENCODER = 'sentence-transformers/all-MiniLM-L6-v2'
+SECTIONS_SPARSE_ENCODER = os.environ.get("SECTIONS_SPARSE_ENCODER", "Qdrant/bm25")
 SNIPPET_ENCODER = 'mixedbread-ai/mxbai-embed-large-v1'
 
 SEARCH_LIMIT = 5

--- a/site_search/sections.py
+++ b/site_search/sections.py
@@ -21,7 +21,7 @@ from qdrant_client.http.models import (
     TokenizerType,
     VectorParams,
 )
-from qdrant_client.models import PayloadSchemaType
+from qdrant_client.models import Modifier, PayloadSchemaType, SparseVectorParams
 from usp.fetch_parse import SitemapFetcher
 from usp.objects.sitemap import IndexWebsiteSitemap, InvalidSitemap
 from usp.tree import sitemap_tree_for_homepage
@@ -65,11 +65,15 @@ class Section(BaseModel):
         # Use the first 16 bytes of the hash to create a UUID
         return str(uuid.UUID(bytes=content_hash[:16]))
 
-    def as_point(self, model: str) -> PointStruct:
+    def as_point(self, model: str, sparse_model: str | None = None) -> PointStruct:
+        vector = Document(text=self.content, model=model)
+        if sparse_model is not None:
+            # "" is the default (unnamed) dense vector; bm25 rides alongside for hybrid search
+            vector = {"": vector, "bm25": Document(text=self.content, model=sparse_model)}
         return PointStruct(
             id=self.uuid,
             payload=self.metadata,
-            vector=Document(text=self.content, model=model),
+            vector=vector,
         )
 
 
@@ -208,6 +212,10 @@ def main():
             size=qdrant_client.get_embedding_size(NEURAL_ENCODER),
             distance=Distance.COSINE,
         ),
+        # bm25 sparse vectors alongside the dense ones: purely-semantic ranking loses to
+        # vocabulary collisions (a query naming an exact API term can rank a topically-similar
+        # tutorial above the reference page); hybrid dense+bm25 with RRF fixes that class.
+        sparse_vectors_config={"bm25": SparseVectorParams(modifier=Modifier.IDF)},
     )
 
     qdrant_client.create_payload_index(
@@ -274,7 +282,8 @@ def main():
             qdrant_client.upsert(
                 SECTION_COLLECTION_NAME,
                 points=[
-                    section.as_point(NEURAL_ENCODER) for section in result.sections
+                    section.as_point(NEURAL_ENCODER, SECTIONS_SPARSE_ENCODER)
+                    for section in result.sections
                 ],
             )
 

--- a/site_search/sections_service.py
+++ b/site_search/sections_service.py
@@ -9,12 +9,16 @@ from qdrant_client.http.models import (
     Document,
     FieldCondition,
     Filter,
+    Fusion,
+    FusionQuery,
     MatchValue,
+    Prefetch,
 )
 from starlette.datastructures import URL
 
 from site_search.config import (
     NEURAL_ENCODER,
+    SECTIONS_SPARSE_ENCODER,
     QDRANT_API_KEY,
     QDRANT_HOST,
     QDRANT_PORT,
@@ -116,13 +120,41 @@ class SectionSearcher:
                     sections=[Section.parse_obj(p.payload) for p in result.points]
                 )
             
-            # If no results, fallback to approximate search
-            result = self.client.query_points(
-                SECTION_COLLECTION_NAME,
-                query=Document(text=query, model=NEURAL_ENCODER),
-                query_filter=Filter(must=conditions),
-                limit=SECTIONS_SEARCH_LIMIT,
-            )
+            # If no results, fall back to hybrid search: dense (semantic) + bm25 (lexical),
+            # RRF-fused. Dense-only ranking loses to vocabulary collisions -- e.g. a query
+            # using the Recommend API's own words ("positive and negative examples") can rank
+            # a topically-similar tutorial above the API reference, and "what distance
+            # metrics ..." can rank the monitoring-metrics page above the collections page.
+            # The lexical channel anchors exact terminology; RRF keeps semantic recall.
+            try:
+                result = self.client.query_points(
+                    SECTION_COLLECTION_NAME,
+                    prefetch=[
+                        Prefetch(
+                            query=Document(text=query, model=NEURAL_ENCODER),
+                            using="",
+                            filter=Filter(must=conditions),
+                            limit=SECTIONS_SEARCH_LIMIT * 5,
+                        ),
+                        Prefetch(
+                            query=Document(text=query, model=SECTIONS_SPARSE_ENCODER),
+                            using="bm25",
+                            filter=Filter(must=conditions),
+                            limit=SECTIONS_SEARCH_LIMIT * 5,
+                        ),
+                    ],
+                    query=FusionQuery(fusion=Fusion.RRF),
+                    limit=SECTIONS_SEARCH_LIMIT,
+                )
+            except Exception:
+                # Collection indexed before the bm25 sparse vectors existed: keep serving
+                # dense-only until the next crawl recreates it with the hybrid schema.
+                result = self.client.query_points(
+                    SECTION_COLLECTION_NAME,
+                    query=Document(text=query, model=NEURAL_ENCODER),
+                    query_filter=Filter(must=conditions),
+                    limit=SECTIONS_SEARCH_LIMIT,
+                )
             return SectionSearchResult(
                 sections=[Section.parse_obj(p.payload) for p in result.points]
             )


### PR DESCRIPTION
## Problem

The `/md/<collection>?q=` section search ranks purely by dense similarity (`all-MiniLM-L6-v2`). Purely-semantic ranking loses to **vocabulary collisions** — a query phrased in a page's own API terminology can rank a topically-similar page above the reference that actually answers it.

Two live repros against `search.qdrant.tech/md/documentation`:

| query | returns | expected |
|---|---|---|
| `how do I get recommendations using positive and negative example points` | a movie-recommendation **tutorial** section (with no canonical doc links) | the Recommend API reference |
| `what distance metrics does Qdrant support` | cloud **cluster-monitoring** metrics | `concepts/collections` (distance metrics) |

We hit these building a grounded docs-QA tool that rides this index; on a 20-question golden set the section search scores **19/20 (0.95)**, and both misses are this collision class.

## Fix

Hybrid retrieval — the pattern Qdrant's own docs recommend:

- **Index** (`sections.py`): a `Qdrant/bm25` sparse vector (IDF modifier) alongside the existing unnamed dense vector.
- **Query** (`sections_service.py`): the approximate-search fallback becomes two prefetches (dense + bm25, same payload filter) fused with **RRF**. The lexical channel anchors exact terminology; RRF keeps semantic recall.
- **Deployment-safe**: if the live collection predates the sparse schema, the service falls back to dense-only until the next crawl (which already recreates the collection from scratch). `SECTIONS_SPARSE_ENCODER` env-overridable.

No changes to the exact-slug-match fast path, the browse path, or response shapes.
