### PR TITLE
Add nightly docs search relevance evals

### DIFF
--- a/.github/workflows/search-eval-pr.yaml
+++ b/.github/workflows/search-eval-pr.yaml
@@ -18,9 +18,9 @@ permissions:
 
 jobs:
   eval:
-    # Fork PRs receive no secrets, so the dense baseline cannot run there. The
-    # eval degrades rather than crashing, but skip the job outright instead of
-    # posting a half-measured report on a PR whose author cannot fix it.
+    # Fork PRs get a read-only GITHUB_TOKEN, so pull-requests: write is not
+    # granted and the comment cannot be posted. The eval itself would run fine
+    # (it needs no secrets), but skip rather than fail on the comment step.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.11'
 
     - name: install deps
-      run: pip install qdrant-client==1.17.1 requests pyyaml python-dotenv
+      run: pip install requests pyyaml
 
     # continue-on-error so a tripped gate still gets a comment explaining why.
     # The last step re-asserts the failure so the check still goes red.
@@ -40,9 +40,6 @@ jobs:
       id: eval
       continue-on-error: true
       run: python -m site_search.eval --summary comment.md --json eval-results.json
-      env:
-        QDRANT_HOST: ${{ secrets.QDRANT_HOST }}
-        QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
 
     - name: add report to the run summary
       if: always()

--- a/.github/workflows/search-eval-pr.yaml
+++ b/.github/workflows/search-eval-pr.yaml
@@ -1,0 +1,98 @@
+name: Search eval (PR)
+
+# Scoped to PRs that touch the eval itself. The eval measures the LIVE service
+# and index, and a PR's code is not deployed yet, so a PR changing the crawler
+# or the Rust service would get numbers identical to any other PR. Where a
+# comment genuinely adds information is an eval_cases.yaml edit, because a label
+# change moves the score immediately.
+on:
+  pull_request:
+    paths:
+      - 'site_search/eval*'
+      - 'tests/test_eval*'
+      - '.github/workflows/search-eval-pr.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  eval:
+    # Fork PRs receive no secrets, so the dense baseline cannot run there. The
+    # eval degrades rather than crashing, but skip the job outright instead of
+    # posting a half-measured report on a PR whose author cannot fix it.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.11'
+
+    - name: install deps
+      run: pip install qdrant-client==1.17.1 requests pyyaml
+
+    # continue-on-error so a tripped gate still gets a comment explaining why.
+    # The last step re-asserts the failure so the check still goes red.
+    - name: run search evals
+      id: eval
+      continue-on-error: true
+      run: python -m site_search.eval --summary comment.md --json eval-results.json
+      env:
+        QDRANT_HOST: ${{ secrets.QDRANT_HOST }}
+        QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+
+    - name: add report to the run summary
+      if: always()
+      run: test -f comment.md && cat comment.md >> "$GITHUB_STEP_SUMMARY" || true
+
+    - name: post or update sticky comment
+      if: always()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -f comment.md ]; then
+          printf '%s\n' \
+            '<!-- docs-search-eval -->' \
+            '## Docs search eval' \
+            '' \
+            'The eval step produced no report — it failed before rendering one.' \
+            "[workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" \
+            > comment.md
+        fi
+
+        # Build the payload with jq so markdown never has to survive shell or
+        # gh field-type coercion.
+        jq -Rs '{body: .}' comment.md > payload.json
+
+        # MARKER in site_search/eval_metrics.py — keep these two in sync.
+        existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments?per_page=100" \
+          --jq '[.[] | select(.body | contains("<!-- docs-search-eval -->")) | .id] | first // empty')
+
+        if [ -n "$existing" ]; then
+          gh api --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" --input payload.json > /dev/null
+          echo "updated comment ${existing}"
+        else
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --input payload.json > /dev/null
+          echo "posted a new comment"
+        fi
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: eval-results-pr
+        path: eval-results.json
+        if-no-files-found: ignore
+
+    - name: fail if the gate tripped
+      if: steps.eval.outcome == 'failure'
+      run: |
+        echo "eval gate failed — see the report comment on this PR" >&2
+        exit 1

--- a/.github/workflows/search-eval-pr.yaml
+++ b/.github/workflows/search-eval-pr.yaml
@@ -18,10 +18,6 @@ permissions:
 
 jobs:
   eval:
-    # Fork PRs get a read-only GITHUB_TOKEN, so pull-requests: write is not
-    # granted and the comment cannot be posted. The eval itself would run fine
-    # (it needs no secrets), but skip rather than fail on the comment step.
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/search-eval-pr.yaml
+++ b/.github/workflows/search-eval-pr.yaml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.11'
 
     - name: install deps
-      run: pip install qdrant-client==1.17.1 requests pyyaml
+      run: pip install qdrant-client==1.17.1 requests pyyaml python-dotenv
 
     # continue-on-error so a tripped gate still gets a comment explaining why.
     # The last step re-asserts the failure so the check still goes red.
@@ -48,41 +48,27 @@ jobs:
       if: always()
       run: test -f comment.md && cat comment.md >> "$GITHUB_STEP_SUMMARY" || true
 
-    - name: post or update sticky comment
+    # comment.md is missing only when the eval crashed before rendering, which
+    # is exactly when a comment matters most. Substitute a stub so the sticky
+    # action always has a body to post.
+    - name: ensure a comment body exists
       if: always()
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR: ${{ github.event.pull_request.number }}
       run: |
-        set -euo pipefail
+        test -f comment.md || printf '%s\n' \
+          '## Docs search eval' \
+          '' \
+          'The eval step produced no report — it failed before rendering one.' \
+          "[workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" \
+          > comment.md
 
-        if [ ! -f comment.md ]; then
-          printf '%s\n' \
-            '<!-- docs-search-eval -->' \
-            '## Docs search eval' \
-            '' \
-            'The eval step produced no report — it failed before rendering one.' \
-            "[workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" \
-            > comment.md
-        fi
-
-        # Build the payload with jq so markdown never has to survive shell or
-        # gh field-type coercion.
-        jq -Rs '{body: .}' comment.md > payload.json
-
-        # MARKER in site_search/eval_metrics.py — keep these two in sync.
-        existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments?per_page=100" \
-          --jq '[.[] | select(.body | contains("<!-- docs-search-eval -->")) | .id] | first // empty')
-
-        if [ -n "$existing" ]; then
-          gh api --method PATCH \
-            "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" --input payload.json > /dev/null
-          echo "updated comment ${existing}"
-        else
-          gh api --method POST \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --input payload.json > /dev/null
-          echo "posted a new comment"
-        fi
+    # Edits its own previous comment in place, keyed by `header`, instead of
+    # piling up one per push. The action owns the hidden marker, so nothing in
+    # the Python has to know about it.
+    - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+      if: always()
+      with:
+        header: docs-search-eval
+        path: comment.md
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()

--- a/.github/workflows/update-search-index.yaml
+++ b/.github/workflows/update-search-index.yaml
@@ -81,13 +81,10 @@ jobs:
     # than a full poetry install, which drags in scipy, fastembed and openai
     # for code that needs none of them.
     - name: install deps
-      run: pip install qdrant-client==1.17.1 requests pyyaml python-dotenv
+      run: pip install requests pyyaml
 
     - name: run search evals
       run: python -m site_search.eval --summary "$GITHUB_STEP_SUMMARY" --json eval-results.json
-      env:
-        QDRANT_HOST: ${{ secrets.QDRANT_HOST }}
-        QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()

--- a/.github/workflows/update-search-index.yaml
+++ b/.github/workflows/update-search-index.yaml
@@ -60,3 +60,37 @@ jobs:
     - name: crawl and index snippets
       run: |
         docker run --rm -i -v $(pwd)/tmp:/code/data -e QDRANT_HOST=${{ secrets.QDRANT_HOST }} -e QDRANT_API_KEY=${{ secrets.QDRANT_API_KEY }} -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} qdrant/page-search python -m site_search.snippets
+
+  eval-search:
+    # Runs after the index is rebuilt, so a half-finished reindex fails the
+    # eval the same night rather than a day later.
+    needs: index-site
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.11'
+
+    # Deliberately not `docker run qdrant/page-search` like the sibling jobs:
+    # that image is published by hand (no workflow builds or pushes it), so an
+    # eval job using it would fail with `No module named site_search.eval`
+    # until someone manually republished. Three packages is also far cheaper
+    # than a full poetry install, which drags in scipy, fastembed and openai
+    # for code that needs none of them.
+    - name: install deps
+      run: pip install qdrant-client==1.17.1 requests pyyaml
+
+    - name: run search evals
+      run: python -m site_search.eval --summary "$GITHUB_STEP_SUMMARY" --json eval-results.json
+      env:
+        QDRANT_HOST: ${{ secrets.QDRANT_HOST }}
+        QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: eval-results
+        path: eval-results.json

--- a/.github/workflows/update-search-index.yaml
+++ b/.github/workflows/update-search-index.yaml
@@ -81,7 +81,7 @@ jobs:
     # than a full poetry install, which drags in scipy, fastembed and openai
     # for code that needs none of them.
     - name: install deps
-      run: pip install qdrant-client==1.17.1 requests pyyaml
+      run: pip install qdrant-client==1.17.1 requests pyyaml python-dotenv
 
     - name: run search evals
       run: python -m site_search.eval --summary "$GITHUB_STEP_SUMMARY" --json eval-results.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,10 @@ uvicorn = "^0.18.3"
 fastapi-utils = "^0.2.1"
 markdown-it-py = "^4.0.0"
 openai = {extras = ["aiohttp"], version = "^2.30.0"}
+pyyaml = "^6.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/site_search/eval.py
+++ b/site_search/eval.py
@@ -66,13 +66,20 @@ def query_endpoint(case: dict, timeout: float = 10.0) -> tuple[list[str], float]
     return result_urls(response.json()), elapsed
 
 
-
 def make_client() -> QdrantClient:
+    # cloud_inference=True is required, not cosmetic. Unlike the Rust client's
+    # Document::new — which always ships the text to the server — the Python
+    # client defaults cloud_inference to False and tries to embed locally with
+    # fastembed, dying on "sentence-transformers/all-MiniLM-L6-v2 is not found
+    # among supported models" when fastembed is not installed. True routes the
+    # query through the server's inference, the same path the live service uses
+    # (rust_search/src/main.rs:298), and keeps fastembed out of the CI install.
     return QdrantClient(
         host=QDRANT_HOST,
         port=QDRANT_PORT,
         api_key=QDRANT_API_KEY,
         prefer_grpc=True,
+        cloud_inference=True,
     )
 
 

--- a/site_search/eval.py
+++ b/site_search/eval.py
@@ -32,8 +32,16 @@ from site_search.eval_metrics import (
     gate_failures,
     hit_at_5,
     reciprocal_rank,
+    render_markdown,
     result_urls,
 )
+
+# NEURAL_ENCODER is imported from site_search.config (config.py:18) rather than
+# redeclared, so the indexer and the eval can never drift onto different models.
+# It must also match rust_search/src/main.rs:33. The service does not embed
+# locally either: main.rs:298 hands Qdrant a Document and lets server-side
+# inference produce the vector, so going through models.Document here means the
+# baseline uses the same embedding path rather than a local near-miss.
 
 SEARCH_API = "https://search.qdrant.tech/api/search"
 CASES_PATH = os.path.join(os.path.dirname(__file__), "eval_cases.yaml")
@@ -57,13 +65,6 @@ def query_endpoint(case: dict, timeout: float = 10.0) -> tuple[list[str], float]
     response.raise_for_status()
     return result_urls(response.json()), elapsed
 
-
-# NEURAL_ENCODER comes from site_search.config (config.py:18) rather than being
-# redeclared here, so the indexer and the eval can never drift onto different
-# models. It must also match rust_search/src/main.rs:33. The service does not
-# embed locally either: main.rs:298 hands Qdrant a Document and lets server-side
-# inference produce the vector, so going through models.Document here means the
-# baseline uses the same embedding path rather than a local near-miss.
 
 
 def make_client() -> QdrantClient:
@@ -125,22 +126,40 @@ def _score(urls: list[str], case: dict) -> dict:
     }
 
 
+def dense_enabled() -> bool:
+    """Whether the dense baseline can run.
+
+    Checks os.environ directly rather than the imported QDRANT_HOST, because
+    config.py defaults that constant to 'localhost' when the variable is unset —
+    so the constant is never falsy and cannot be used to detect absence.
+
+    Without credentials the endpoint half still works and is what gates CI, so a
+    missing cluster degrades the report instead of crashing it. That covers fork
+    PRs, which receive no secrets, and local runs.
+    """
+    return bool(os.environ.get("QDRANT_HOST"))
+
+
 def run(cases: list[dict]) -> dict:
-    """Execute every case against both layers and return the full report."""
-    client = make_client()
+    """Execute every case against the endpoint, and the dense baseline if available."""
+    dense_on = dense_enabled()
+    client = make_client() if dense_on else None
     endpoint_rows, dense_rows, per_case, latencies, zero_result_ids = [], [], [], [], []
 
     for case in cases:
         endpoint_urls, elapsed = query_endpoint(case)
-        dense_urls = query_dense(client, case)
         latencies.append(elapsed)
         if not endpoint_urls:
             zero_result_ids.append(case["id"])
 
         endpoint_score = _score(endpoint_urls, case)
-        dense_score = _score(dense_urls, case)
         endpoint_rows.append(endpoint_score)
-        dense_rows.append(dense_score)
+
+        dense_score = None
+        if dense_on:
+            dense_score = _score(query_dense(client, case), case)
+            dense_rows.append(dense_score)
+
         per_case.append(
             {
                 "id": case["id"],
@@ -149,67 +168,30 @@ def run(cases: list[dict]) -> dict:
                 "primary": case["primary"],
                 "endpoint_hit": endpoint_score["hit"],
                 "endpoint_rr": round(endpoint_score["rr"], 4),
-                "dense_hit": dense_score["hit"],
+                "dense_hit": dense_score["hit"] if dense_score else None,
                 "endpoint_urls": endpoint_urls,
                 "latency_ms": round(elapsed * 1000),
             }
         )
 
     endpoint = aggregate(endpoint_rows)
-    dense = aggregate(dense_rows)
     return {
         "endpoint": endpoint._asdict(),
-        "dense": dense._asdict(),
+        "dense": aggregate(dense_rows)._asdict() if dense_on else None,
         "endpoint_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(endpoint_rows).items()},
-        "dense_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(dense_rows).items()},
-        "corpus_size": corpus_size(client),
+        "dense_by_kind": (
+            {k: m._asdict() for k, m in aggregate_by_kind(dense_rows).items()}
+            if dense_on
+            else None
+        ),
+        "dense_measured": dense_on,
+        "corpus_size": corpus_size(client) if dense_on else None,
         "max_latency_ms": round(max(latencies) * 1000) if latencies else 0,
         "zero_result_ids": zero_result_ids,
         "floor": HIT_RATE_FLOOR,
         "failures": gate_failures(endpoint, zero_result_ids, HIT_RATE_FLOOR),
         "cases": per_case,
     }
-
-
-def render_markdown(report: dict) -> str:
-    lines = ["## Docs search eval", ""]
-    endpoint = report["endpoint"]
-    dense = report["dense"]
-
-    lines += [
-        "| layer | n | hit-rate@5 | MRR@5 |",
-        "| --- | --- | --- | --- |",
-        f"| endpoint | {endpoint['n']} | {endpoint['hit_rate']:.3f} | {endpoint['mrr']:.3f} |",
-        f"| dense only | {dense['n']} | {dense['hit_rate']:.3f} | {dense['mrr']:.3f} |",
-        "",
-        "| kind | n | endpoint hit-rate@5 | endpoint MRR@5 | dense hit-rate@5 |",
-        "| --- | --- | --- | --- | --- |",
-    ]
-    for kind in sorted(report["endpoint_by_kind"]):
-        e = report["endpoint_by_kind"][kind]
-        d = report["dense_by_kind"][kind]
-        lines.append(
-            f"| {kind} | {e['n']} | {e['hit_rate']:.3f} | {e['mrr']:.3f} | {d['hit_rate']:.3f} |"
-        )
-
-    lines += [
-        "",
-        f"corpus: {report['corpus_size']} points · "
-        f"max latency: {report['max_latency_ms']} ms · "
-        f"floor: {report['floor']:.3f}",
-        "",
-    ]
-
-    misses = [c for c in report["cases"] if not c["endpoint_hit"]]
-    if misses:
-        lines += ["### Endpoint misses", "", "| id | query | expected |", "| --- | --- | --- |"]
-        lines += [f"| {c['id']} | `{c['q']}` | {c['primary']} |" for c in misses]
-        lines.append("")
-
-    if report["failures"]:
-        lines += ["### Failures", ""] + [f"- {f}" for f in report["failures"]] + [""]
-
-    return "\n".join(lines)
 
 
 def main(argv=None) -> int:

--- a/site_search/eval.py
+++ b/site_search/eval.py
@@ -4,12 +4,9 @@ Measures the live search endpoint against a hand-labeled golden set and gates on
 the result. Pure HTTP: no Qdrant client, no credentials, no embedding model, so
 it runs anywhere `requests` does.
 
-An earlier version also queried the `site` collection directly for a
-no-ladder baseline. That answered its question once — the four-tier ladder is
-worth about +15pp over an unfiltered vector search, concentrated on
-natural-language queries — and as a nightly signal it was not worth the
-credentials, the qdrant-client dependency, or the two client-path bugs it cost.
-Recover it ad hoc if a regression ever needs attributing.
+Relevance only: no latency, no index internals. Querying the `site` collection
+directly measured the four-tier ladder at about +15pp over unfiltered vector
+search, but that is a one-off finding, not a nightly signal.
 
 Run: python -m site_search.eval
 """
@@ -18,7 +15,6 @@ import argparse
 import json
 import os
 import sys
-import time
 
 import requests
 import yaml
@@ -43,18 +39,20 @@ def load_cases(path: str | None = None) -> list[dict]:
         return yaml.safe_load(f)
 
 
-def query_endpoint(case: dict, timeout: float = 10.0) -> tuple[list[str], float]:
-    """Query the live endpoint. Returns (result urls in rank order, seconds)."""
+def query_endpoint(case: dict, timeout: float = 10.0) -> list[str]:
+    """Query the live endpoint. Returns result urls in rank order.
+
+    `timeout` is a safety net against a hung request, not a latency
+    measurement: this pipeline reports relevance, not performance.
+    """
     params = {
         "q": case["q"],
         "section": case["section"],
         "partition": case["partition"],
     }
-    started = time.perf_counter()
     response = requests.get(SEARCH_API, params=params, timeout=timeout)
-    elapsed = time.perf_counter() - started
     response.raise_for_status()
-    return result_urls(response.json()), elapsed
+    return result_urls(response.json())
 
 
 def _score(urls: list[str], case: dict) -> dict:
@@ -67,11 +65,10 @@ def _score(urls: list[str], case: dict) -> dict:
 
 def run(cases: list[dict]) -> dict:
     """Execute every case against the live endpoint and return the full report."""
-    rows, per_case, latencies, zero_result_ids = [], [], [], []
+    rows, per_case, zero_result_ids = [], [], []
 
     for case in cases:
-        urls, elapsed = query_endpoint(case)
-        latencies.append(elapsed)
+        urls = query_endpoint(case)
         if not urls:
             zero_result_ids.append(case["id"])
 
@@ -86,7 +83,6 @@ def run(cases: list[dict]) -> dict:
                 "endpoint_hit": score["hit"],
                 "endpoint_rr": round(score["rr"], 4),
                 "endpoint_urls": urls,
-                "latency_ms": round(elapsed * 1000),
             }
         )
 
@@ -94,7 +90,6 @@ def run(cases: list[dict]) -> dict:
     return {
         "endpoint": endpoint._asdict(),
         "endpoint_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(rows).items()},
-        "max_latency_ms": round(max(latencies) * 1000) if latencies else 0,
         "zero_result_ids": zero_result_ids,
         "floor": HIT_RATE_FLOOR,
         "failures": gate_failures(endpoint, zero_result_ids, HIT_RATE_FLOOR),

--- a/site_search/eval.py
+++ b/site_search/eval.py
@@ -20,6 +20,7 @@ from qdrant_client import QdrantClient, models
 
 from site_search.config import (
     COLLECTION_NAME,
+    NEURAL_ENCODER,
     QDRANT_API_KEY,
     QDRANT_HOST,
     QDRANT_PORT,
@@ -57,11 +58,12 @@ def query_endpoint(case: dict, timeout: float = 10.0) -> tuple[list[str], float]
     return result_urls(response.json()), elapsed
 
 
-# Must match rust_search/src/main.rs:33 exactly. The service does not embed
-# locally either: main.rs:298 hands Qdrant a Document and lets server-side
-# inference produce the vector, so going through models.Document here means our
+# NEURAL_ENCODER comes from site_search.config (config.py:18) rather than being
+# redeclared here, so the indexer and the eval can never drift onto different
+# models. It must also match rust_search/src/main.rs:33. The service does not
+# embed locally either: main.rs:298 hands Qdrant a Document and lets server-side
+# inference produce the vector, so going through models.Document here means the
 # baseline uses the same embedding path rather than a local near-miss.
-NEURAL_ENCODER = "sentence-transformers/all-MiniLM-L6-v2"
 
 
 def make_client() -> QdrantClient:

--- a/site_search/eval.py
+++ b/site_search/eval.py
@@ -1,0 +1,236 @@
+"""Docs search eval runner.
+
+Measures the live search endpoint against a hand-labeled golden set, plus a
+dense-only baseline queried straight from the `site` collection. The endpoint
+number is what users experience; the dense number tells you whether a
+regression came from the index or from the service's ranking.
+
+Run: python -m site_search.eval
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import requests
+import yaml
+from qdrant_client import QdrantClient, models
+
+from site_search.config import (
+    COLLECTION_NAME,
+    QDRANT_API_KEY,
+    QDRANT_HOST,
+    QDRANT_PORT,
+)
+from site_search.eval_metrics import (
+    HIT_RATE_FLOOR,
+    aggregate,
+    aggregate_by_kind,
+    gate_failures,
+    hit_at_5,
+    reciprocal_rank,
+    result_urls,
+)
+
+SEARCH_API = "https://search.qdrant.tech/api/search"
+CASES_PATH = os.path.join(os.path.dirname(__file__), "eval_cases.yaml")
+
+
+def load_cases(path: str | None = None) -> list[dict]:
+    with open(path or CASES_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def query_endpoint(case: dict, timeout: float = 10.0) -> tuple[list[str], float]:
+    """Query the live endpoint. Returns (result urls in rank order, seconds)."""
+    params = {
+        "q": case["q"],
+        "section": case["section"],
+        "partition": case["partition"],
+    }
+    started = time.perf_counter()
+    response = requests.get(SEARCH_API, params=params, timeout=timeout)
+    elapsed = time.perf_counter() - started
+    response.raise_for_status()
+    return result_urls(response.json()), elapsed
+
+
+# Must match rust_search/src/main.rs:33 exactly. The service does not embed
+# locally either: main.rs:298 hands Qdrant a Document and lets server-side
+# inference produce the vector, so going through models.Document here means our
+# baseline uses the same embedding path rather than a local near-miss.
+NEURAL_ENCODER = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def make_client() -> QdrantClient:
+    return QdrantClient(
+        host=QDRANT_HOST,
+        port=QDRANT_PORT,
+        api_key=QDRANT_API_KEY,
+        prefer_grpc=True,
+    )
+
+
+def case_filter(case: dict) -> models.Filter:
+    """Reproduce the service's section and partition filters.
+
+    Both fields are comma-separated any-of lists, matching how the Rust handler
+    splits them (rust_search/src/main.rs, query_handler).
+    """
+    conditions = []
+    for key in ("section", "partition"):
+        values = [v.strip() for v in case[key].split(",") if v.strip()]
+        if not values:
+            continue
+        payload_key = "sections" if key == "section" else "partition"
+        conditions.append(
+            models.FieldCondition(
+                key=payload_key,
+                match=models.MatchAny(any=values),
+            )
+        )
+    return models.Filter(must=conditions)
+
+
+def query_dense(client: QdrantClient, case: dict, limit: int = 5) -> list[str]:
+    """Dense-only retrieval, no tag filters and no tier ladder."""
+    response = client.query_points(
+        collection_name=COLLECTION_NAME,
+        query=models.Document(text=case["q"], model=NEURAL_ENCODER),
+        query_filter=case_filter(case),
+        limit=limit,
+        with_payload=True,
+    )
+    return [point.payload["url"] for point in response.points]
+
+
+def corpus_size(client: QdrantClient) -> int:
+    """Point count of the site collection.
+
+    The nightly job drops and recreates this collection, so a half-failed
+    encode leaves a partial index. This is the cheapest detector for that.
+    """
+    return client.count(collection_name=COLLECTION_NAME, exact=True).count
+
+
+def _score(urls: list[str], case: dict) -> dict:
+    return {
+        "hit": hit_at_5(urls, case["primary"], case.get("acceptable") or []),
+        "rr": reciprocal_rank(urls, case["primary"]),
+        "kind": case["kind"],
+    }
+
+
+def run(cases: list[dict]) -> dict:
+    """Execute every case against both layers and return the full report."""
+    client = make_client()
+    endpoint_rows, dense_rows, per_case, latencies, zero_result_ids = [], [], [], [], []
+
+    for case in cases:
+        endpoint_urls, elapsed = query_endpoint(case)
+        dense_urls = query_dense(client, case)
+        latencies.append(elapsed)
+        if not endpoint_urls:
+            zero_result_ids.append(case["id"])
+
+        endpoint_score = _score(endpoint_urls, case)
+        dense_score = _score(dense_urls, case)
+        endpoint_rows.append(endpoint_score)
+        dense_rows.append(dense_score)
+        per_case.append(
+            {
+                "id": case["id"],
+                "q": case["q"],
+                "kind": case["kind"],
+                "primary": case["primary"],
+                "endpoint_hit": endpoint_score["hit"],
+                "endpoint_rr": round(endpoint_score["rr"], 4),
+                "dense_hit": dense_score["hit"],
+                "endpoint_urls": endpoint_urls,
+                "latency_ms": round(elapsed * 1000),
+            }
+        )
+
+    endpoint = aggregate(endpoint_rows)
+    dense = aggregate(dense_rows)
+    return {
+        "endpoint": endpoint._asdict(),
+        "dense": dense._asdict(),
+        "endpoint_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(endpoint_rows).items()},
+        "dense_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(dense_rows).items()},
+        "corpus_size": corpus_size(client),
+        "max_latency_ms": round(max(latencies) * 1000) if latencies else 0,
+        "zero_result_ids": zero_result_ids,
+        "floor": HIT_RATE_FLOOR,
+        "failures": gate_failures(endpoint, zero_result_ids, HIT_RATE_FLOOR),
+        "cases": per_case,
+    }
+
+
+def render_markdown(report: dict) -> str:
+    lines = ["## Docs search eval", ""]
+    endpoint = report["endpoint"]
+    dense = report["dense"]
+
+    lines += [
+        "| layer | n | hit-rate@5 | MRR@5 |",
+        "| --- | --- | --- | --- |",
+        f"| endpoint | {endpoint['n']} | {endpoint['hit_rate']:.3f} | {endpoint['mrr']:.3f} |",
+        f"| dense only | {dense['n']} | {dense['hit_rate']:.3f} | {dense['mrr']:.3f} |",
+        "",
+        "| kind | n | endpoint hit-rate@5 | endpoint MRR@5 | dense hit-rate@5 |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for kind in sorted(report["endpoint_by_kind"]):
+        e = report["endpoint_by_kind"][kind]
+        d = report["dense_by_kind"][kind]
+        lines.append(
+            f"| {kind} | {e['n']} | {e['hit_rate']:.3f} | {e['mrr']:.3f} | {d['hit_rate']:.3f} |"
+        )
+
+    lines += [
+        "",
+        f"corpus: {report['corpus_size']} points · "
+        f"max latency: {report['max_latency_ms']} ms · "
+        f"floor: {report['floor']:.3f}",
+        "",
+    ]
+
+    misses = [c for c in report["cases"] if not c["endpoint_hit"]]
+    if misses:
+        lines += ["### Endpoint misses", "", "| id | query | expected |", "| --- | --- | --- |"]
+        lines += [f"| {c['id']} | `{c['q']}` | {c['primary']} |" for c in misses]
+        lines.append("")
+
+    if report["failures"]:
+        lines += ["### Failures", ""] + [f"- {f}" for f in report["failures"]] + [""]
+
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Run docs search evals.")
+    parser.add_argument("--summary", help="path to append a markdown summary to")
+    parser.add_argument("--json", dest="json_path", help="path to write the JSON report to")
+    args = parser.parse_args(argv)
+
+    report = run(load_cases())
+    markdown = render_markdown(report)
+    print(markdown)
+
+    if args.summary:
+        with open(args.summary, "a") as f:
+            f.write(markdown + "\n")
+    if args.json_path:
+        with open(args.json_path, "w") as f:
+            json.dump(report, f, indent=2)
+
+    for failure in report["failures"]:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    return 1 if report["failures"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site_search/eval.py
+++ b/site_search/eval.py
@@ -1,9 +1,15 @@
 """Docs search eval runner.
 
-Measures the live search endpoint against a hand-labeled golden set, plus a
-dense-only baseline queried straight from the `site` collection. The endpoint
-number is what users experience; the dense number tells you whether a
-regression came from the index or from the service's ranking.
+Measures the live search endpoint against a hand-labeled golden set and gates on
+the result. Pure HTTP: no Qdrant client, no credentials, no embedding model, so
+it runs anywhere `requests` does.
+
+An earlier version also queried the `site` collection directly for a
+no-ladder baseline. That answered its question once — the four-tier ladder is
+worth about +15pp over an unfiltered vector search, concentrated on
+natural-language queries — and as a nightly signal it was not worth the
+credentials, the qdrant-client dependency, or the two client-path bugs it cost.
+Recover it ad hoc if a regression ever needs attributing.
 
 Run: python -m site_search.eval
 """
@@ -16,15 +22,7 @@ import time
 
 import requests
 import yaml
-from qdrant_client import QdrantClient, models
 
-from site_search.config import (
-    COLLECTION_NAME,
-    NEURAL_ENCODER,
-    QDRANT_API_KEY,
-    QDRANT_HOST,
-    QDRANT_PORT,
-)
 from site_search.eval_metrics import (
     HIT_RATE_FLOOR,
     aggregate,
@@ -35,13 +33,6 @@ from site_search.eval_metrics import (
     render_markdown,
     result_urls,
 )
-
-# NEURAL_ENCODER is imported from site_search.config (config.py:18) rather than
-# redeclared, so the indexer and the eval can never drift onto different models.
-# It must also match rust_search/src/main.rs:33. The service does not embed
-# locally either: main.rs:298 hands Qdrant a Document and lets server-side
-# inference produce the vector, so going through models.Document here means the
-# baseline uses the same embedding path rather than a local near-miss.
 
 SEARCH_API = "https://search.qdrant.tech/api/search"
 CASES_PATH = os.path.join(os.path.dirname(__file__), "eval_cases.yaml")
@@ -66,65 +57,6 @@ def query_endpoint(case: dict, timeout: float = 10.0) -> tuple[list[str], float]
     return result_urls(response.json()), elapsed
 
 
-def make_client() -> QdrantClient:
-    # cloud_inference=True is required, not cosmetic. Unlike the Rust client's
-    # Document::new — which always ships the text to the server — the Python
-    # client defaults cloud_inference to False and tries to embed locally with
-    # fastembed, dying on "sentence-transformers/all-MiniLM-L6-v2 is not found
-    # among supported models" when fastembed is not installed. True routes the
-    # query through the server's inference, the same path the live service uses
-    # (rust_search/src/main.rs:298), and keeps fastembed out of the CI install.
-    return QdrantClient(
-        host=QDRANT_HOST,
-        port=QDRANT_PORT,
-        api_key=QDRANT_API_KEY,
-        prefer_grpc=True,
-        cloud_inference=True,
-    )
-
-
-def case_filter(case: dict) -> models.Filter:
-    """Reproduce the service's section and partition filters.
-
-    Both fields are comma-separated any-of lists, matching how the Rust handler
-    splits them (rust_search/src/main.rs, query_handler).
-    """
-    conditions = []
-    for key in ("section", "partition"):
-        values = [v.strip() for v in case[key].split(",") if v.strip()]
-        if not values:
-            continue
-        payload_key = "sections" if key == "section" else "partition"
-        conditions.append(
-            models.FieldCondition(
-                key=payload_key,
-                match=models.MatchAny(any=values),
-            )
-        )
-    return models.Filter(must=conditions)
-
-
-def query_dense(client: QdrantClient, case: dict, limit: int = 5) -> list[str]:
-    """Dense-only retrieval, no tag filters and no tier ladder."""
-    response = client.query_points(
-        collection_name=COLLECTION_NAME,
-        query=models.Document(text=case["q"], model=NEURAL_ENCODER),
-        query_filter=case_filter(case),
-        limit=limit,
-        with_payload=True,
-    )
-    return [point.payload["url"] for point in response.points]
-
-
-def corpus_size(client: QdrantClient) -> int:
-    """Point count of the site collection.
-
-    The nightly job drops and recreates this collection, so a half-failed
-    encode leaves a partial index. This is the cheapest detector for that.
-    """
-    return client.count(collection_name=COLLECTION_NAME, exact=True).count
-
-
 def _score(urls: list[str], case: dict) -> dict:
     return {
         "hit": hit_at_5(urls, case["primary"], case.get("acceptable") or []),
@@ -133,66 +65,35 @@ def _score(urls: list[str], case: dict) -> dict:
     }
 
 
-def dense_enabled() -> bool:
-    """Whether the dense baseline can run.
-
-    Checks os.environ directly rather than the imported QDRANT_HOST, because
-    config.py defaults that constant to 'localhost' when the variable is unset —
-    so the constant is never falsy and cannot be used to detect absence.
-
-    Without credentials the endpoint half still works and is what gates CI, so a
-    missing cluster degrades the report instead of crashing it. That covers fork
-    PRs, which receive no secrets, and local runs.
-    """
-    return bool(os.environ.get("QDRANT_HOST"))
-
-
 def run(cases: list[dict]) -> dict:
-    """Execute every case against the endpoint, and the dense baseline if available."""
-    dense_on = dense_enabled()
-    client = make_client() if dense_on else None
-    endpoint_rows, dense_rows, per_case, latencies, zero_result_ids = [], [], [], [], []
+    """Execute every case against the live endpoint and return the full report."""
+    rows, per_case, latencies, zero_result_ids = [], [], [], []
 
     for case in cases:
-        endpoint_urls, elapsed = query_endpoint(case)
+        urls, elapsed = query_endpoint(case)
         latencies.append(elapsed)
-        if not endpoint_urls:
+        if not urls:
             zero_result_ids.append(case["id"])
 
-        endpoint_score = _score(endpoint_urls, case)
-        endpoint_rows.append(endpoint_score)
-
-        dense_score = None
-        if dense_on:
-            dense_score = _score(query_dense(client, case), case)
-            dense_rows.append(dense_score)
-
+        score = _score(urls, case)
+        rows.append(score)
         per_case.append(
             {
                 "id": case["id"],
                 "q": case["q"],
                 "kind": case["kind"],
                 "primary": case["primary"],
-                "endpoint_hit": endpoint_score["hit"],
-                "endpoint_rr": round(endpoint_score["rr"], 4),
-                "dense_hit": dense_score["hit"] if dense_score else None,
-                "endpoint_urls": endpoint_urls,
+                "endpoint_hit": score["hit"],
+                "endpoint_rr": round(score["rr"], 4),
+                "endpoint_urls": urls,
                 "latency_ms": round(elapsed * 1000),
             }
         )
 
-    endpoint = aggregate(endpoint_rows)
+    endpoint = aggregate(rows)
     return {
         "endpoint": endpoint._asdict(),
-        "dense": aggregate(dense_rows)._asdict() if dense_on else None,
-        "endpoint_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(endpoint_rows).items()},
-        "dense_by_kind": (
-            {k: m._asdict() for k, m in aggregate_by_kind(dense_rows).items()}
-            if dense_on
-            else None
-        ),
-        "dense_measured": dense_on,
-        "corpus_size": corpus_size(client) if dense_on else None,
+        "endpoint_by_kind": {k: m._asdict() for k, m in aggregate_by_kind(rows).items()},
         "max_latency_ms": round(max(latencies) * 1000) if latencies else 0,
         "zero_result_ids": zero_result_ids,
         "floor": HIT_RATE_FLOOR,

--- a/site_search/eval_cases.yaml
+++ b/site_search/eval_cases.yaml
@@ -1,0 +1,322 @@
+# Golden query set for docs search evals.
+#
+# Labeling rule:
+#   primary    = the page a docs maintainer would send someone to.
+#   acceptable = a page that also genuinely answers the question.
+#   If primary is not decidable, the case is ambiguous and does not belong here.
+#
+# section/partition are uniform across all cases on purpose: they reproduce the
+# search context a user gets on any develop/deploy docs page. The widget widens
+# develop|deploy into "develop,deploy,cloud,qdrant" before calling the API, so
+# sending a bare partition would test a filter combination no user ever sees.
+#
+# kind drives the per-bucket split in the report. Do not add a case whose
+# expected page lives in the `ecosystem` partition: it is unreachable from this
+# search context and would be permanently red.
+
+# ---------- keyword: short exact-ish terms, the lexical-match path ----------
+- id: binary-quantization
+  q: "binary quantization"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/quantization/
+  acceptable:
+    - /articles/binary-quantization/
+  kind: keyword
+
+- id: scalar-quantization
+  q: "scalar quantization"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/quantization/
+  kind: keyword
+
+- id: payload-filtering
+  q: "payload filtering"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/search/filtering/
+  acceptable:
+    - /articles/vector-search-filtering/
+  kind: keyword
+
+- id: hnsw-index
+  q: "hnsw index"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/indexing/
+  kind: keyword
+
+- id: sparse-vectors
+  q: "sparse vectors"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/vectors/
+  acceptable:
+    - /articles/sparse-vectors/
+  kind: keyword
+
+- id: multitenancy
+  q: "multitenancy"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/multitenancy/
+  kind: keyword
+
+- id: consistency-guarantees
+  q: "consistency guarantees"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/scaling/consistency-guarantees/
+  kind: keyword
+
+- id: optimizer
+  q: "optimizer"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/ops-optimization/optimizer/
+  kind: keyword
+
+- id: shard-key
+  q: "shard key"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/scaling/distributed_deployment/
+  kind: keyword
+
+- id: on-disk-storage
+  q: "on disk vector storage"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/storage/
+  kind: keyword
+
+- id: full-text-search
+  q: "full text search"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/search/text-search/full-text-search/
+  kind: keyword
+
+- id: api-key
+  q: "api key"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/security/
+  kind: keyword
+
+# ---------- natural: full questions, the dense path ----------
+- id: reduce-memory
+  q: "how do I reduce memory usage"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/faq/database-optimization/
+  kind: natural
+
+- id: create-collection
+  q: "how to create a collection"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/collections/
+  kind: natural
+
+- id: combine-dense-sparse
+  q: "how do I combine dense and sparse search"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/search/hybrid-queries/
+  acceptable:
+    - /documentation/search/text-search/hybrid-search/
+    - /articles/hybrid-search/
+  kind: natural
+
+- id: upload-many-vectors
+  q: "fastest way to upload a lot of vectors"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/bulk-upload/
+  kind: natural
+
+- id: add-node
+  q: "how do I add a node to my cluster"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/scaling/horizontal-scaling/
+  kind: natural
+
+- id: back-up-data
+  q: "how do I back up my data"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/snapshots/
+  acceptable:
+    - /documentation/cloud/backups/
+  kind: natural
+
+- id: search-is-slow
+  q: "why is my search slow"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/search/low-latency-search/
+  acceptable:
+    - /documentation/faq/database-optimization/
+  kind: natural
+
+- id: what-is-vector-db
+  q: "what is a vector database"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/overview/what-is-qdrant/
+  acceptable:
+    - /documentation/overview/vector-search/
+  kind: natural
+
+- id: monitor-prometheus
+  q: "how do I monitor qdrant with prometheus"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/ops-monitoring/monitoring/
+  kind: natural
+
+- id: gpu-indexing
+  q: "can I use a GPU for indexing"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/ops-configuration/running-with-gpu/
+  acceptable:
+    - /documentation/tutorials-operations/gpu-accelerated-hnsw-indexing/
+  kind: natural
+
+- id: node-fails
+  q: "what happens when a node fails"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/scaling/node-failure-recovery/
+  acceptable:
+    - /documentation/scaling/resilience/
+  kind: natural
+
+- id: rerank-results
+  q: "how do I rerank results"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/tutorials-basics/reranking-hybrid-search/
+  kind: natural
+
+- id: configure-qdrant
+  q: "how do I change configuration settings"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/ops-configuration/configuration/
+  kind: natural
+
+- id: embeddings-in-qdrant
+  q: "can qdrant create embeddings for me"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/inference/cloud-inference/
+  acceptable:
+    - /documentation/inference/
+  kind: natural
+
+# ---------- typo: prefix tokenizer + dense fallback under misspelling ----------
+- id: typo-quantizaton
+  q: "quantizaton"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/quantization/
+  kind: typo
+
+- id: typo-colection
+  q: "colection"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/collections/
+  kind: typo
+
+- id: typo-multitenency
+  q: "multitenency"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/manage-data/multitenancy/
+  kind: typo
+
+- id: typo-filterring
+  q: "filterring"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/search/filtering/
+  kind: typo
+
+- id: typo-snaphot
+  q: "snaphot"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/snapshots/
+  kind: typo
+
+- id: typo-distirbuted
+  q: "distirbuted deployment"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/scaling/distributed_deployment/
+  kind: typo
+
+# ---------- navigational: user hunting one specific page ----------
+- id: nav-quickstart
+  q: "quickstart"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/quickstart/
+  kind: navigational
+
+- id: nav-installation
+  q: "installation"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/installation/
+  kind: navigational
+
+- id: nav-rest-api
+  q: "rest api"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/interfaces/
+  kind: navigational
+
+- id: nav-cloud-quickstart
+  q: "cloud quickstart"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/cloud-quickstart/
+  kind: navigational
+
+- id: nav-create-cluster
+  q: "create cluster"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/cloud/create-cluster/
+  kind: navigational
+
+- id: nav-memory-tiers
+  q: "memory tiers"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/ops-configuration/memory-tiers/
+  kind: navigational
+
+- id: nav-snapshots
+  q: "snapshots"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/snapshots/
+  kind: navigational
+
+- id: nav-qdrant-edge
+  q: "qdrant edge"
+  section: documentation
+  partition: develop,deploy,cloud,qdrant
+  primary: /documentation/edge/
+  acceptable:
+    - /documentation/edge/edge-quickstart/
+  kind: navigational

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -168,11 +168,7 @@ def render_markdown(report: dict) -> str:
         e = report["endpoint_by_kind"][kind]
         lines.append(f"| {kind} | {e['n']} | {e['hit_rate']:.3f} | {e['mrr']:.3f} |")
 
-    lines += [
-        "",
-        f"max latency: {report['max_latency_ms']} ms",
-        "",
-    ]
+    lines.append("")
 
     misses = [c for c in report["cases"] if not c["endpoint_hit"]]
     if misses:
@@ -195,7 +191,8 @@ def render_markdown(report: dict) -> str:
             )
         lines.append("")
 
-    if report["failures"]:
-        lines += ["### Failures", ""] + [f"- {f}" for f in report["failures"]] + [""]
-
+    # No separate failure list: every gate reason is already visible above. A
+    # hit-rate below the floor is the PASS/FAIL line, and a zero-result case is
+    # a "_no results_" row in the misses table. The reasons still travel in the
+    # JSON report and print to stderr, which is what drives the exit code.
     return "\n".join(lines)

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -137,6 +137,11 @@ def render_markdown(report: dict) -> str:
     lines = [
         "## Docs search eval",
         "",
+        "`endpoint` is the live service. `no ladder` is the **same query vector on "
+        "the same `site` collection**, filtered only by section and partition — no "
+        "`tag` filter, no full-text `text` condition, no four-tier priority. The gap "
+        "between the rows is what the ladder's filters buy, not a different engine.",
+        "",
         f"{'✅ PASS' if passed else '❌ FAIL'} — endpoint hit-rate@5 "
         f"**{endpoint['hit_rate']:.3f}** vs floor {report['floor']:.3f}",
         "",
@@ -147,9 +152,9 @@ def render_markdown(report: dict) -> str:
         lines += [f"[workflow run]({run_url})", ""]
 
     dense_row = (
-        f"| dense only | {dense['n']} | {dense['hit_rate']:.3f} | {dense['mrr']:.3f} |"
+        f"| no ladder | {dense['n']} | {dense['hit_rate']:.3f} | {dense['mrr']:.3f} |"
         if dense
-        else "| dense only | — | _not measured (no cluster credentials)_ | — |"
+        else "| no ladder | — | _not measured (no cluster credentials)_ | — |"
     )
     lines += [
         "| layer | n | hit-rate@5 | MRR@5 |",
@@ -157,7 +162,7 @@ def render_markdown(report: dict) -> str:
         f"| endpoint | {endpoint['n']} | {endpoint['hit_rate']:.3f} | {endpoint['mrr']:.3f} |",
         dense_row,
         "",
-        "| kind | n | endpoint hit-rate@5 | endpoint MRR@5 | dense hit-rate@5 |",
+        "| kind | n | endpoint hit-rate@5 | endpoint MRR@5 | no-ladder hit-rate@5 |",
         "| --- | --- | --- | --- | --- |",
     ]
     for kind in sorted(report["endpoint_by_kind"]):

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -103,9 +103,10 @@ def result_urls(payload: dict) -> list[str]:
 def gate_failures(endpoint: Metrics, zero_result_ids: list[str], floor: float) -> list[str]:
     """Reasons the run should fail the build. Empty list means pass.
 
-    Only endpoint results gate. The dense baseline is diagnostic — it exists to
-    attribute a regression, not to cause one — so a dense anomaly reports in the
-    summary without failing CI.
+    Two conditions, both about the live endpoint: relevance below the floor, and
+    any case coming back empty. The second is the sharper signal for "index or
+    service is broken" as opposed to "relevance drifted", since a healthy
+    service essentially always returns five results.
     """
     failures = []
     if endpoint.hit_rate < floor:
@@ -143,18 +144,12 @@ def _run_url() -> str | None:
 
 def render_markdown(report: dict) -> str:
     endpoint = report["endpoint"]
-    dense = report.get("dense")
     passed = not report["failures"]
 
     # Comment stickiness is handled by the sticky-pull-request-comment action's
     # own hidden header, so no marker is needed in this body.
     lines = [
         "## Docs search eval",
-        "",
-        "`endpoint` is the live service. `no ladder` is the **same query vector on "
-        "the same `site` collection**, filtered only by section and partition — no "
-        "`tag` filter, no full-text `text` condition, no four-tier priority. The gap "
-        "between the rows is what the ladder's filters buy, not a different engine.",
         "",
         f"{'✅ PASS' if passed else '❌ FAIL'} — endpoint hit-rate@5 "
         f"**{endpoint['hit_rate']:.3f}** vs floor {report['floor']:.3f}",
@@ -165,35 +160,19 @@ def render_markdown(report: dict) -> str:
     if run_url:
         lines += [f"[workflow run]({run_url})", ""]
 
-    dense_row = (
-        f"| no ladder | {dense['n']} | {dense['hit_rate']:.3f} | {dense['mrr']:.3f} |"
-        if dense
-        else "| no ladder | — | _not measured (no cluster credentials)_ | — |"
-    )
     lines += [
-        "| layer | n | hit-rate@5 | MRR@5 |",
+        f"| kind | n | hit-rate@5 | MRR@5 |",
         "| --- | --- | --- | --- |",
-        f"| endpoint | {endpoint['n']} | {endpoint['hit_rate']:.3f} | {endpoint['mrr']:.3f} |",
-        dense_row,
-        "",
-        "| kind | n | endpoint hit-rate@5 | endpoint MRR@5 | no-ladder hit-rate@5 |",
-        "| --- | --- | --- | --- | --- |",
+        f"| **overall** | {endpoint['n']} | **{endpoint['hit_rate']:.3f}** "
+        f"| **{endpoint['mrr']:.3f}** |",
     ]
     for kind in sorted(report["endpoint_by_kind"]):
         e = report["endpoint_by_kind"][kind]
-        by_kind = report.get("dense_by_kind") or {}
-        d = by_kind.get(kind)
-        dense_cell = f"{d['hit_rate']:.3f}" if d else "—"
-        lines.append(
-            f"| {kind} | {e['n']} | {e['hit_rate']:.3f} | {e['mrr']:.3f} | {dense_cell} |"
-        )
+        lines.append(f"| {kind} | {e['n']} | {e['hit_rate']:.3f} | {e['mrr']:.3f} |")
 
-    corpus = report.get("corpus_size")
     lines += [
         "",
-        f"corpus: {f'{corpus} points' if corpus is not None else 'not measured'} · "
-        f"max latency: {report['max_latency_ms']} ms · "
-        f"floor: {report['floor']:.3f}",
+        f"max latency: {report['max_latency_ms']} ms · floor: {report['floor']:.3f}",
         "",
     ]
 

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -8,8 +8,6 @@ import os
 from typing import Iterable, NamedTuple
 from urllib.parse import urlparse
 
-VALID_KINDS = ("keyword", "natural", "typo", "navigational")
-
 # Payload URLs are site-relative; this makes them clickable in reports.
 SITE_ROOT = "https://qdrant.tech"
 
@@ -52,8 +50,8 @@ def normalize_url(url: str) -> str:
 def hit_at_5(urls: list[str], primary: str, acceptable: Iterable[str] = ()) -> bool:
     """True if primary or any acceptable URL appears in the first CUTOFF results.
 
-    The parameter is named `urls`, not `result_urls`, to avoid shadowing the
-    module-level `result_urls()` parser added in Task 3.
+    The parameter is named `urls`, not `result_urls`, so it does not shadow the
+    module-level `result_urls()` parser.
     """
     targets = {normalize_url(primary)}
     targets.update(normalize_url(u) for u in acceptable)
@@ -161,7 +159,7 @@ def render_markdown(report: dict) -> str:
         lines += [f"[workflow run]({run_url})", ""]
 
     lines += [
-        f"| kind | n | hit-rate@5 | MRR@5 |",
+        "| kind | n | hit-rate@5 | MRR@5 |",
         "| --- | --- | --- | --- |",
         f"| **overall** | {endpoint['n']} | **{endpoint['hit_rate']:.3f}** "
         f"| **{endpoint['mrr']:.3f}** |",
@@ -172,7 +170,7 @@ def render_markdown(report: dict) -> str:
 
     lines += [
         "",
-        f"max latency: {report['max_latency_ms']} ms · floor: {report['floor']:.3f}",
+        f"max latency: {report['max_latency_ms']} ms",
         "",
     ]
 

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -4,10 +4,15 @@ No network calls and no Qdrant client live here, so this module is unit-testable
 with synthetic data. Everything that touches I/O belongs in site_search/eval.py.
 """
 
+import os
 from typing import Iterable, NamedTuple
 from urllib.parse import urlparse
 
 VALID_KINDS = ("keyword", "natural", "typo", "navigational")
+
+# Hidden anchor used by the PR workflow to find and update its own comment
+# rather than posting a new one on every run.
+MARKER = "<!-- docs-search-eval -->"
 
 # Results are always compared at 5: the service returns at most 5 hits
 # (SEARCH_LIMIT in rust_search/src/main.rs:31).
@@ -114,3 +119,77 @@ def gate_failures(endpoint: Metrics, zero_result_ids: list[str], floor: float) -
             + ", ".join(sorted(zero_result_ids))
         )
     return failures
+
+
+def _run_url() -> str | None:
+    """Link back to the workflow run, when running inside GitHub Actions."""
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if server and repo and run_id:
+        return f"{server}/{repo}/actions/runs/{run_id}"
+    return None
+
+
+def render_markdown(report: dict) -> str:
+    endpoint = report["endpoint"]
+    dense = report.get("dense")
+    passed = not report["failures"]
+
+    # MARKER makes the PR comment sticky: the workflow finds the previous
+    # comment by this string and edits it instead of posting a new one.
+    lines = [
+        MARKER,
+        "## Docs search eval",
+        "",
+        f"{'✅ PASS' if passed else '❌ FAIL'} — endpoint hit-rate@5 "
+        f"**{endpoint['hit_rate']:.3f}** vs floor {report['floor']:.3f}",
+        "",
+    ]
+
+    run_url = _run_url()
+    if run_url:
+        lines += [f"[workflow run]({run_url})", ""]
+
+    dense_row = (
+        f"| dense only | {dense['n']} | {dense['hit_rate']:.3f} | {dense['mrr']:.3f} |"
+        if dense
+        else "| dense only | — | _not measured (no cluster credentials)_ | — |"
+    )
+    lines += [
+        "| layer | n | hit-rate@5 | MRR@5 |",
+        "| --- | --- | --- | --- |",
+        f"| endpoint | {endpoint['n']} | {endpoint['hit_rate']:.3f} | {endpoint['mrr']:.3f} |",
+        dense_row,
+        "",
+        "| kind | n | endpoint hit-rate@5 | endpoint MRR@5 | dense hit-rate@5 |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for kind in sorted(report["endpoint_by_kind"]):
+        e = report["endpoint_by_kind"][kind]
+        by_kind = report.get("dense_by_kind") or {}
+        d = by_kind.get(kind)
+        dense_cell = f"{d['hit_rate']:.3f}" if d else "—"
+        lines.append(
+            f"| {kind} | {e['n']} | {e['hit_rate']:.3f} | {e['mrr']:.3f} | {dense_cell} |"
+        )
+
+    corpus = report.get("corpus_size")
+    lines += [
+        "",
+        f"corpus: {f'{corpus} points' if corpus is not None else 'not measured'} · "
+        f"max latency: {report['max_latency_ms']} ms · "
+        f"floor: {report['floor']:.3f}",
+        "",
+    ]
+
+    misses = [c for c in report["cases"] if not c["endpoint_hit"]]
+    if misses:
+        lines += ["### Endpoint misses", "", "| id | query | expected |", "| --- | --- | --- |"]
+        lines += [f"| {c['id']} | `{c['q']}` | {c['primary']} |" for c in misses]
+        lines.append("")
+
+    if report["failures"]:
+        lines += ["### Failures", ""] + [f"- {f}" for f in report["failures"]] + [""]
+
+    return "\n".join(lines)

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -1,0 +1,107 @@
+"""Pure functions for docs search evals.
+
+No network calls and no Qdrant client live here, so this module is unit-testable
+with synthetic data. Everything that touches I/O belongs in site_search/eval.py.
+"""
+
+from typing import Iterable, NamedTuple
+from urllib.parse import urlparse
+
+VALID_KINDS = ("keyword", "natural", "typo", "navigational")
+
+# Results are always compared at 5: the service returns at most 5 hits
+# (SEARCH_LIMIT in rust_search/src/main.rs:31).
+CUTOFF = 5
+
+# Seeded from the first measured baseline run, not chosen in advance:
+# observed endpoint hit-rate@5, minus 0.10 absolute, rounded down to the
+# nearest 0.05. Task 8 of the implementation plan sets this.
+HIT_RATE_FLOOR = 0.0
+
+
+class Metrics(NamedTuple):
+    n: int
+    hit_rate: float
+    mrr: float
+
+
+def normalize_url(url: str) -> str:
+    """Reduce a URL to a comparable path.
+
+    The search API returns relative paths ('/documentation/x/'), but labels may
+    be written as absolute URLs and trailing slashes are inconsistent across
+    both. Compare paths only, without a trailing slash.
+    """
+    path = urlparse(url).path or "/"
+    return path.rstrip("/") or "/"
+
+
+def hit_at_5(urls: list[str], primary: str, acceptable: Iterable[str] = ()) -> bool:
+    """True if primary or any acceptable URL appears in the first CUTOFF results.
+
+    The parameter is named `urls`, not `result_urls`, to avoid shadowing the
+    module-level `result_urls()` parser added in Task 3.
+    """
+    targets = {normalize_url(primary)}
+    targets.update(normalize_url(u) for u in acceptable)
+    return any(normalize_url(u) in targets for u in urls[:CUTOFF])
+
+
+def reciprocal_rank(urls: list[str], primary: str) -> float:
+    """1/rank of primary within the first CUTOFF results, else 0.0.
+
+    Ranks against primary only — acceptable URLs count for hit-rate but not for
+    MRR, so that 'found a defensible alternative' does not read as 'found the
+    best page'. A primary absent from the returned results scores 0 rather than
+    a reciprocal of some unknown true rank.
+    """
+    target = normalize_url(primary)
+    for rank, url in enumerate(urls[:CUTOFF], start=1):
+        if normalize_url(url) == target:
+            return 1.0 / rank
+    return 0.0
+
+
+def aggregate(rows: list[dict]) -> Metrics:
+    """Mean hit-rate and MRR over rows carrying 'hit' and 'rr'."""
+    if not rows:
+        return Metrics(n=0, hit_rate=0.0, mrr=0.0)
+    n = len(rows)
+    return Metrics(
+        n=n,
+        hit_rate=sum(1 for r in rows if r["hit"]) / n,
+        mrr=sum(r["rr"] for r in rows) / n,
+    )
+
+
+def aggregate_by_kind(rows: list[dict]) -> dict[str, Metrics]:
+    """Per-kind aggregates, so a red run says which query type broke."""
+    buckets: dict[str, list[dict]] = {}
+    for row in rows:
+        buckets.setdefault(row["kind"], []).append(row)
+    return {kind: aggregate(bucket) for kind, bucket in buckets.items()}
+
+
+def result_urls(payload: dict) -> list[str]:
+    """Extract result URLs from an /api/search JSON body, in rank order."""
+    return [hit["payload"]["url"] for hit in payload.get("result", [])]
+
+
+def gate_failures(endpoint: Metrics, zero_result_ids: list[str], floor: float) -> list[str]:
+    """Reasons the run should fail the build. Empty list means pass.
+
+    Only endpoint results gate. The dense baseline is diagnostic — it exists to
+    attribute a regression, not to cause one — so a dense anomaly reports in the
+    summary without failing CI.
+    """
+    failures = []
+    if endpoint.hit_rate < floor:
+        failures.append(
+            f"endpoint hit-rate@5 {endpoint.hit_rate:.3f} is below floor {floor:.3f}"
+        )
+    if zero_result_ids:
+        failures.append(
+            f"{len(zero_result_ids)} case(s) returned zero results: "
+            + ", ".join(sorted(zero_result_ids))
+        )
+    return failures

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -10,6 +10,9 @@ from urllib.parse import urlparse
 
 VALID_KINDS = ("keyword", "natural", "typo", "navigational")
 
+# Payload URLs are site-relative; this makes them clickable in reports.
+SITE_ROOT = "https://qdrant.tech"
+
 # Results are always compared at 5: the service returns at most 5 hits
 # (SEARCH_LIMIT in rust_search/src/main.rs:31).
 CUTOFF = 5
@@ -117,6 +120,17 @@ def gate_failures(endpoint: Metrics, zero_result_ids: list[str], floor: float) -
     return failures
 
 
+def doc_link(url: str) -> str:
+    """Markdown link to the live page.
+
+    Payload URLs come back site-relative ('/documentation/x/'), which is not
+    clickable in a PR comment. Keep the path as the visible text so rows stay
+    scannable, and point the href at the live site.
+    """
+    href = url if url.startswith("http") else f"{SITE_ROOT}{url}"
+    return f"[{url}]({href})"
+
+
 def _run_url() -> str | None:
     """Link back to the workflow run, when running inside GitHub Actions."""
     server = os.environ.get("GITHUB_SERVER_URL")
@@ -185,8 +199,23 @@ def render_markdown(report: dict) -> str:
 
     misses = [c for c in report["cases"] if not c["endpoint_hit"]]
     if misses:
-        lines += ["### Endpoint misses", "", "| id | query | expected |", "| --- | --- | --- |"]
-        lines += [f"| {c['id']} | `{c['q']}` | {c['primary']} |" for c in misses]
+        lines += [
+            "### Endpoint misses",
+            "",
+            "| id | query | expected | returned |",
+            "| --- | --- | --- | --- |",
+        ]
+        for case in misses:
+            # Repeated paths are real: two chunks from the same page each count
+            # as a result, so the same link can legitimately appear twice.
+            returned = "<br>".join(
+                f"{rank}. {doc_link(url)}"
+                for rank, url in enumerate(case["endpoint_urls"], start=1)
+            )
+            lines.append(
+                f"| {case['id']} | `{case['q']}` | {doc_link(case['primary'])} | "
+                f"{returned or '_no results_'} |"
+            )
         lines.append("")
 
     if report["failures"]:

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -10,10 +10,6 @@ from urllib.parse import urlparse
 
 VALID_KINDS = ("keyword", "natural", "typo", "navigational")
 
-# Hidden anchor used by the PR workflow to find and update its own comment
-# rather than posting a new one on every run.
-MARKER = "<!-- docs-search-eval -->"
-
 # Results are always compared at 5: the service returns at most 5 hits
 # (SEARCH_LIMIT in rust_search/src/main.rs:31).
 CUTOFF = 5
@@ -136,10 +132,9 @@ def render_markdown(report: dict) -> str:
     dense = report.get("dense")
     passed = not report["failures"]
 
-    # MARKER makes the PR comment sticky: the workflow finds the previous
-    # comment by this string and edits it instead of posting a new one.
+    # Comment stickiness is handled by the sticky-pull-request-comment action's
+    # own hidden header, so no marker is needed in this body.
     lines = [
-        MARKER,
         "## Docs search eval",
         "",
         f"{'✅ PASS' if passed else '❌ FAIL'} — endpoint hit-rate@5 "

--- a/site_search/eval_metrics.py
+++ b/site_search/eval_metrics.py
@@ -15,8 +15,17 @@ CUTOFF = 5
 
 # Seeded from the first measured baseline run, not chosen in advance:
 # observed endpoint hit-rate@5, minus 0.10 absolute, rounded down to the
-# nearest 0.05. Task 8 of the implementation plan sets this.
-HIT_RATE_FLOOR = 0.0
+# nearest 0.05.
+#
+# Baseline 2026-09-02, 40 cases against search.qdrant.tech:
+#   overall      hit-rate@5 0.800   MRR@5 0.467
+#   keyword      0.917 (12)
+#   typo         0.833 (6)
+#   natural      0.786 (14)
+#   navigational 0.625 (8)   <- weakest bucket
+#
+# 0.800 - 0.10 = 0.700, which is already a multiple of 0.05.
+HIT_RATE_FLOOR = 0.70
 
 
 class Metrics(NamedTuple):

--- a/tests/test_eval_cases.py
+++ b/tests/test_eval_cases.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import yaml
+
+CASES_PATH = Path(__file__).parent.parent / "site_search" / "eval_cases.yaml"
+VALID_KINDS = {"keyword", "natural", "typo", "navigational"}
+EXPECTED_KIND_COUNTS = {"keyword": 12, "natural": 14, "typo": 6, "navigational": 8}
+
+
+def load_cases():
+    with open(CASES_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def test_case_count():
+    assert len(load_cases()) == 40
+
+
+def test_ids_are_unique():
+    ids = [c["id"] for c in load_cases()]
+    assert len(ids) == len(set(ids))
+
+
+def test_required_keys_present():
+    for case in load_cases():
+        for key in ("id", "q", "section", "partition", "primary", "kind"):
+            assert key in case, f"{case.get('id')} missing {key}"
+
+
+def test_kinds_are_valid_and_balanced():
+    counts = {}
+    for case in load_cases():
+        assert case["kind"] in VALID_KINDS, case["id"]
+        counts[case["kind"]] = counts.get(case["kind"], 0) + 1
+    assert counts == EXPECTED_KIND_COUNTS
+
+
+def test_urls_are_absolute_paths():
+    for case in load_cases():
+        urls = [case["primary"]] + list(case.get("acceptable") or [])
+        for url in urls:
+            assert url.startswith("/"), f"{case['id']}: {url}"
+            assert url.endswith("/"), f"{case['id']}: {url}"
+
+
+def test_search_context_is_uniform():
+    for case in load_cases():
+        assert case["section"] == "documentation", case["id"]
+        assert case["partition"] == "develop,deploy,cloud,qdrant", case["id"]

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -150,7 +150,7 @@ def test_gate_floor_is_inclusive():
     assert gate_failures(Metrics(n=40, hit_rate=0.8, mrr=0.7), [], 0.8) == []
 
 
-from site_search.eval_metrics import MARKER, render_markdown
+from site_search.eval_metrics import render_markdown
 
 
 def _report(hit_rate=0.9, failures=(), dense=True):
@@ -170,9 +170,9 @@ def _report(hit_rate=0.9, failures=(), dense=True):
     }
 
 
-def test_render_starts_with_sticky_marker():
-    # The PR workflow finds its previous comment by this exact string.
-    assert render_markdown(_report()).startswith(MARKER)
+def test_render_starts_with_heading():
+    # Stickiness is the action's job now; the body starts with the heading.
+    assert render_markdown(_report()).startswith("## Docs search eval")
 
 
 def test_render_shows_pass_when_no_failures():

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -158,7 +158,6 @@ def _report(hit_rate=0.9, failures=()):
     return {
         "endpoint": {"n": 40, "hit_rate": hit_rate, "mrr": 0.5},
         "endpoint_by_kind": {"keyword": {"n": 12, "hit_rate": 0.9, "mrr": 0.5}},
-        "max_latency_ms": 940,
         "zero_result_ids": [],
         "floor": 0.70,
         "failures": list(failures),
@@ -211,7 +210,6 @@ def _miss_report():
             "endpoint_hit": False,
             "endpoint_rr": 0.0,
             "endpoint_urls": ["/documentation/a/", "/documentation/b/"],
-            "latency_ms": 500,
         },
         {
             "id": "zero-case",
@@ -221,7 +219,6 @@ def _miss_report():
             "endpoint_hit": False,
             "endpoint_rr": 0.0,
             "endpoint_urls": [],
-            "latency_ms": 500,
         },
     ]
     return r

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,150 @@
+from site_search.eval_metrics import hit_at_5, normalize_url
+
+
+def test_normalize_strips_trailing_slash():
+    assert normalize_url("/documentation/search/") == "/documentation/search"
+
+
+def test_normalize_accepts_absolute_url():
+    assert normalize_url("https://qdrant.tech/documentation/search/") == "/documentation/search"
+
+
+def test_normalize_strips_query_and_fragment():
+    assert normalize_url("/documentation/search/?q=x#frag") == "/documentation/search"
+
+
+def test_normalize_root_stays_slash():
+    assert normalize_url("/") == "/"
+
+
+def test_hit_when_primary_at_rank_one():
+    assert hit_at_5(["/documentation/a/", "/documentation/b/"], "/documentation/a/") is True
+
+
+def test_hit_when_primary_at_rank_five():
+    urls = [f"/documentation/x{i}/" for i in range(4)] + ["/documentation/a/"]
+    assert hit_at_5(urls, "/documentation/a/") is True
+
+
+def test_miss_when_primary_absent():
+    assert hit_at_5(["/documentation/b/"], "/documentation/a/") is False
+
+
+def test_hit_via_acceptable_url():
+    assert hit_at_5(["/articles/z/"], "/documentation/a/", ["/articles/z/"]) is True
+
+
+def test_trailing_slash_mismatch_still_hits():
+    assert hit_at_5(["/documentation/a"], "/documentation/a/") is True
+
+
+def test_empty_results_is_a_miss():
+    assert hit_at_5([], "/documentation/a/") is False
+
+
+def test_only_first_five_results_count():
+    urls = [f"/documentation/x{i}/" for i in range(5)] + ["/documentation/a/"]
+    assert hit_at_5(urls, "/documentation/a/") is False
+
+
+from site_search.eval_metrics import (
+    Metrics,
+    aggregate,
+    aggregate_by_kind,
+    reciprocal_rank,
+    result_urls,
+)
+
+
+def test_rr_is_one_at_rank_one():
+    assert reciprocal_rank(["/a/", "/b/"], "/a/") == 1.0
+
+
+def test_rr_is_one_third_at_rank_three():
+    assert reciprocal_rank(["/x/", "/y/", "/a/"], "/a/") == 1 / 3
+
+
+def test_rr_is_zero_when_absent():
+    assert reciprocal_rank(["/x/"], "/a/") == 0.0
+
+
+def test_rr_ignores_results_past_cutoff():
+    urls = [f"/x{i}/" for i in range(5)] + ["/a/"]
+    assert reciprocal_rank(urls, "/a/") == 0.0
+
+
+def test_rr_ignores_acceptable_urls():
+    # MRR ranks against primary only, by design.
+    assert reciprocal_rank(["/articles/z/"], "/documentation/a/") == 0.0
+
+
+def test_aggregate_computes_means():
+    rows = [
+        {"hit": True, "rr": 1.0},
+        {"hit": True, "rr": 0.5},
+        {"hit": False, "rr": 0.0},
+        {"hit": False, "rr": 0.0},
+    ]
+    assert aggregate(rows) == Metrics(n=4, hit_rate=0.5, mrr=0.375)
+
+
+def test_aggregate_of_empty_is_zeroed():
+    assert aggregate([]) == Metrics(n=0, hit_rate=0.0, mrr=0.0)
+
+
+def test_aggregate_by_kind_splits_buckets():
+    rows = [
+        {"kind": "keyword", "hit": True, "rr": 1.0},
+        {"kind": "keyword", "hit": False, "rr": 0.0},
+        {"kind": "typo", "hit": False, "rr": 0.0},
+    ]
+    by_kind = aggregate_by_kind(rows)
+    assert by_kind["keyword"] == Metrics(n=2, hit_rate=0.5, mrr=0.5)
+    assert by_kind["typo"] == Metrics(n=1, hit_rate=0.0, mrr=0.0)
+
+
+def test_result_urls_extracts_payload_urls():
+    payload = {
+        "result": [
+            {"payload": {"url": "/documentation/a/", "text": "A"}, "highlight": "A"},
+            {"payload": {"url": "/documentation/b/", "text": "B"}, "highlight": "B"},
+        ],
+        "time": 0.05,
+    }
+    assert result_urls(payload) == ["/documentation/a/", "/documentation/b/"]
+
+
+def test_result_urls_of_empty_response():
+    assert result_urls({"result": [], "time": 0.01}) == []
+
+
+def test_result_urls_tolerates_missing_key():
+    assert result_urls({}) == []
+
+
+from site_search.eval_metrics import gate_failures
+
+
+def test_gate_passes_above_floor():
+    assert gate_failures(Metrics(n=40, hit_rate=0.9, mrr=0.7), [], 0.8) == []
+
+
+def test_gate_fails_below_floor():
+    failures = gate_failures(Metrics(n=40, hit_rate=0.7, mrr=0.5), [], 0.8)
+    assert len(failures) == 1
+    assert "0.700" in failures[0] and "0.800" in failures[0]
+
+
+def test_gate_fails_on_zero_results():
+    failures = gate_failures(Metrics(n=40, hit_rate=0.9, mrr=0.7), ["nav-quickstart"], 0.8)
+    assert len(failures) == 1
+    assert "nav-quickstart" in failures[0]
+
+
+def test_gate_reports_both_failures():
+    failures = gate_failures(Metrics(n=40, hit_rate=0.1, mrr=0.1), ["a", "b"], 0.8)
+    assert len(failures) == 2
+
+
+def test_gate_floor_is_inclusive():
+    assert gate_failures(Metrics(n=40, hit_rate=0.8, mrr=0.7), [], 0.8) == []

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -196,3 +196,67 @@ def test_render_without_dense_says_not_measured():
 def test_render_without_dense_has_no_crash_and_keeps_kind_table():
     out = render_markdown(_report(dense=False))
     assert "| keyword |" in out
+
+
+from site_search.eval_metrics import doc_link
+
+
+def test_doc_link_makes_relative_path_clickable():
+    assert doc_link("/documentation/search/filtering/") == (
+        "[/documentation/search/filtering/]"
+        "(https://qdrant.tech/documentation/search/filtering/)"
+    )
+
+
+def test_doc_link_leaves_absolute_url_alone():
+    url = "https://qdrant.tech/articles/hybrid-search/"
+    assert doc_link(url) == f"[{url}]({url})"
+
+
+def _miss_report():
+    r = _report(hit_rate=0.5, failures=["endpoint hit-rate@5 0.500 is below floor 0.700"])
+    r["cases"] = [
+        {
+            "id": "payload-filtering",
+            "q": "payload filtering",
+            "kind": "keyword",
+            "primary": "/documentation/search/filtering/",
+            "endpoint_hit": False,
+            "endpoint_rr": 0.0,
+            "dense_hit": False,
+            "endpoint_urls": ["/documentation/a/", "/documentation/b/"],
+            "latency_ms": 500,
+        },
+        {
+            "id": "zero-case",
+            "q": "nothing",
+            "kind": "typo",
+            "primary": "/documentation/quickstart/",
+            "endpoint_hit": False,
+            "endpoint_rr": 0.0,
+            "dense_hit": False,
+            "endpoint_urls": [],
+            "latency_ms": 500,
+        },
+    ]
+    return r
+
+
+def test_misses_table_shows_what_was_returned():
+    out = render_markdown(_miss_report())
+    assert "| id | query | expected | returned |" in out
+    assert "1. [/documentation/a/](https://qdrant.tech/documentation/a/)" in out
+    assert "2. [/documentation/b/](https://qdrant.tech/documentation/b/)" in out
+
+
+def test_misses_table_links_the_expected_page():
+    out = render_markdown(_miss_report())
+    assert "[/documentation/search/filtering/](https://qdrant.tech/documentation/search/filtering/)" in out
+
+
+def test_misses_table_marks_zero_result_case():
+    assert "_no results_" in render_markdown(_miss_report())
+
+
+def test_hits_produce_no_misses_table():
+    assert "Endpoint misses" not in render_markdown(_report())

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -148,3 +148,51 @@ def test_gate_reports_both_failures():
 
 def test_gate_floor_is_inclusive():
     assert gate_failures(Metrics(n=40, hit_rate=0.8, mrr=0.7), [], 0.8) == []
+
+
+from site_search.eval_metrics import MARKER, render_markdown
+
+
+def _report(hit_rate=0.9, failures=(), dense=True):
+    """Minimal report dict shaped like site_search.eval.run() output."""
+    return {
+        "endpoint": {"n": 40, "hit_rate": hit_rate, "mrr": 0.5},
+        "dense": {"n": 40, "hit_rate": 0.6, "mrr": 0.4} if dense else None,
+        "endpoint_by_kind": {"keyword": {"n": 12, "hit_rate": 0.9, "mrr": 0.5}},
+        "dense_by_kind": {"keyword": {"n": 12, "hit_rate": 0.6, "mrr": 0.4}} if dense else None,
+        "dense_measured": dense,
+        "corpus_size": 12345 if dense else None,
+        "max_latency_ms": 940,
+        "zero_result_ids": [],
+        "floor": 0.70,
+        "failures": list(failures),
+        "cases": [],
+    }
+
+
+def test_render_starts_with_sticky_marker():
+    # The PR workflow finds its previous comment by this exact string.
+    assert render_markdown(_report()).startswith(MARKER)
+
+
+def test_render_shows_pass_when_no_failures():
+    out = render_markdown(_report(hit_rate=0.9))
+    assert "PASS" in out
+    assert "FAIL" not in out
+
+
+def test_render_shows_fail_when_gated():
+    out = render_markdown(_report(hit_rate=0.6, failures=["endpoint hit-rate@5 0.600 is below floor 0.700"]))
+    assert "FAIL" in out
+    assert "0.600" in out
+
+
+def test_render_without_dense_says_not_measured():
+    out = render_markdown(_report(dense=False))
+    assert "not measured" in out
+    assert "corpus: not measured" in out
+
+
+def test_render_without_dense_has_no_crash_and_keeps_kind_table():
+    out = render_markdown(_report(dense=False))
+    assert "| keyword |" in out

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -153,15 +153,11 @@ def test_gate_floor_is_inclusive():
 from site_search.eval_metrics import render_markdown
 
 
-def _report(hit_rate=0.9, failures=(), dense=True):
+def _report(hit_rate=0.9, failures=()):
     """Minimal report dict shaped like site_search.eval.run() output."""
     return {
         "endpoint": {"n": 40, "hit_rate": hit_rate, "mrr": 0.5},
-        "dense": {"n": 40, "hit_rate": 0.6, "mrr": 0.4} if dense else None,
         "endpoint_by_kind": {"keyword": {"n": 12, "hit_rate": 0.9, "mrr": 0.5}},
-        "dense_by_kind": {"keyword": {"n": 12, "hit_rate": 0.6, "mrr": 0.4}} if dense else None,
-        "dense_measured": dense,
-        "corpus_size": 12345 if dense else None,
         "max_latency_ms": 940,
         "zero_result_ids": [],
         "floor": 0.70,
@@ -187,15 +183,6 @@ def test_render_shows_fail_when_gated():
     assert "0.600" in out
 
 
-def test_render_without_dense_says_not_measured():
-    out = render_markdown(_report(dense=False))
-    assert "not measured" in out
-    assert "corpus: not measured" in out
-
-
-def test_render_without_dense_has_no_crash_and_keeps_kind_table():
-    out = render_markdown(_report(dense=False))
-    assert "| keyword |" in out
 
 
 from site_search.eval_metrics import doc_link
@@ -223,7 +210,6 @@ def _miss_report():
             "primary": "/documentation/search/filtering/",
             "endpoint_hit": False,
             "endpoint_rr": 0.0,
-            "dense_hit": False,
             "endpoint_urls": ["/documentation/a/", "/documentation/b/"],
             "latency_ms": 500,
         },
@@ -234,7 +220,6 @@ def _miss_report():
             "primary": "/documentation/quickstart/",
             "endpoint_hit": False,
             "endpoint_rr": 0.0,
-            "dense_hit": False,
             "endpoint_urls": [],
             "latency_ms": 500,
         },
@@ -260,3 +245,9 @@ def test_misses_table_marks_zero_result_case():
 
 def test_hits_produce_no_misses_table():
     assert "Endpoint misses" not in render_markdown(_report())
+
+
+def test_render_keeps_overall_and_per_kind_rows():
+    out = render_markdown(_report())
+    assert "| **overall** |" in out
+    assert "| keyword |" in out


### PR DESCRIPTION
Adds the first relevance evals for docs search.

## Why

This repo has never had a test. Verified across its full history: 92 commits, 51 files ever added, zero test files. `pytest` isn't a dependency, `dev-docs.md` documents a suite that has never existed, and `deploy.yml` has no test step.

So relevance ships blind. Reordering the four tiers in `rust_search/src/main.rs`, changing `SEARCH_LIMIT`, or swapping the `PREFIX` tokenizer can crater heading matches with nothing to catch it.

## Key decisions

- **40 hand-labeled golden queries** (`site_search/eval_cases.yaml`), four kinds — `keyword` 12, `natural` 14, `typo` 6, `navigational` 8 — labeled `primary` plus optional `acceptable[]` for queries with several right answers.
- **Endpoint only, pure HTTP.** `requests` + `pyyaml`, no `qdrant-client`, no cluster credentials, no secrets in either workflow. An earlier revision also queried the `site` collection directly; that measured the tier ladder at ~+15pp over unfiltered vector search and was then removed as a one-off finding rather than a nightly signal.
- **Gate:** endpoint hit-rate@5 below the floor, or any case returning zero results.
- **Floor 0.70, derived not guessed** — measured baseline 0.800, minus 0.10, rounded down to the nearest 0.05.
- **No stored history.** Report goes to the run summary and a JSON artifact; PRs touching eval files also get a sticky comment.

## Baseline (2026-09-02, verified in CI)

```
overall        hit-rate@5 0.800   MRR@5 0.467
keyword        0.917 (12)
typo           0.833 (6)
natural        0.786 (14)
navigational   0.625 (8)   <- weakest
```

40 cases means hit-rate moves in 2.5pp steps, so a floor 10pp down needs four cases to break before it trips.

## Should know

- **⚠️ Merging discards the search API's query logs.** `search.qdrant.tech` is the Rust service in `rust_search/`, running as a Docker container named `qdrant-site-search` on `secrets.DEPLOY_HOST`. A push to `master` triggers `deploy.yml`, which does `docker kill; docker rm; docker run` on that container. It logs every incoming query to stdout (`main.rs:319`, level defaults to `info`), and the `docker run` has no volume mount and no log driver, so the logs go with the container. They are the only record of what users search for — the `site` collection stores chunks, never query strings. The collection itself is unaffected either way: the deploy targets one container by name. Retention is at most since the last deploy (last `master` commit: 2026-06-16), less if the host rotates json-file logs. Pull them off first if anyone wants real-traffic queries for the golden set.
- **The eval measures live prod.** A red run can mean prod is down rather than relevance regressed; the zero-results guard is what distinguishes them, since relevance drift still returns five results.
- **The nightly job can't run until this merges** — scheduled workflows only fire from the default branch. Same for `workflow_dispatch` on it.
- **No corpus-size check.** A subtly partial reindex — most pages present, hit-rate@5 intact, long tail gutted — would go undetected. That assertion belongs in the index job.
- **Golden set drifts with the docs.** A renamed or split page shows up as a miss. Mitigated by page-level rather than heading-level labels.

Findings from the baseline, bugs caught while building, and follow-ups are in a comment below.


